### PR TITLE
Minor bugfix found during testing on ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_minimum_required (VERSION 2.8.12)
 
 # Adjust CMake's module path.
@@ -18,6 +19,10 @@ endif()
 if (NOT CMAKE_INSTALL_PREFIX)
   set(CMAKE_INSTALL_PREFIX /usr/local)
 endif()
+
+set(PETSC_ARCH $ENV{PETSC_ARCH})
+set(PETSC_DIR $ENV{PETSC_DIR})
+include($ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/initial_cache_file.cmake)
 
 # Make sure compilers are set. This must be done before enabling languages.
 if (NOT CMAKE_C_COMPILER)
@@ -128,8 +133,6 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 
-set(PETSC_ARCH $ENV{PETSC_ARCH})
-set(PETSC_DIR $ENV{PETSC_DIR})
 find_package(PETSc)
 if (NOT PETSC_FOUND)
   message(FATAL_ERROR "PETSc was not found.")

--- a/src/driver/standalone/thermal/thermal_mms_steady_state_problem_1D.F90
+++ b/src/driver/standalone/thermal/thermal_mms_steady_state_problem_1D.F90
@@ -150,6 +150,7 @@ module thermal_mms_steady_state_problem_1D
         call compute_temperature_or_deriv(x,y,z,T=data_1D(count))
 
      case(DATA_HEAT_SOURCE)
+        jj = 1; kk = 1;
         do ii = 1, nx
            x = soil_xc_3d(ii,1,1)
            y = soil_yc_3d(ii,jj,kk)


### PR DESCRIPTION
- Use PETSc cmake configuration file to determine compilers.
- Initialize uninitialized variables were causing segmentation fault.

Fixes #10 