### PR TITLE
Updates for FETCH2 problem

### DIFF
--- a/src/driver/standalone/thermal-e/heat_transport_1D.F90
+++ b/src/driver/standalone/thermal-e/heat_transport_1D.F90
@@ -173,135 +173,41 @@ subroutine add_meshes()
 #include <petsc/finclude/petsc.h>
   !
   use MultiPhysicsProbThermalEnthalpy , only : thermal_enthalpy_mpp
-  use MultiPhysicsProbConstants       , only : MESH_ALONG_GRAVITY
-  use MultiPhysicsProbConstants       , only : MESH_AGAINST_GRAVITY
-  use MultiPhysicsProbConstants       , only : MESH_CLM_THERMAL_SOIL_COL
-  use MultiPhysicsProbConstants       , only : VAR_XC
-  use MultiPhysicsProbConstants       , only : VAR_YC
-  use MultiPhysicsProbConstants       , only : VAR_ZC
-  use MultiPhysicsProbConstants       , only : VAR_DX
-  use MultiPhysicsProbConstants       , only : VAR_DY
-  use MultiPhysicsProbConstants       , only : VAR_DZ
-  use MultiPhysicsProbConstants       , only : VAR_AREA
-  use MultiPhysicsProbConstants       , only : CONN_SET_INTERNAL
-  use MultiPhysicsProbConstants       , only : CONN_SET_LATERAL
-  use MultiPhysicsProbConstants       , only : CONN_VERTICAL
-  use mesh_info                       , only : nx, ny, x_column, y_column, z_column, nz
-  use mesh_info                       , only : ncells_local, ncells_ghost
-  use mpp_varpar                      , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
-  use petscsys
-  !
-  implicit none
-  !
-  PetscReal          :: dx, dy, dz
-  PetscInt           :: imesh, kk
-  PetscInt           :: nlev
-  PetscInt           :: iconn, vert_nconn
-  PetscReal, pointer :: soil_xc(:)           ! x-position of grid cell [m]
-  PetscReal, pointer :: soil_yc(:)           ! y-position of grid cell [m]
-  PetscReal, pointer :: soil_zc(:)           ! z-position of grid cell [m]
-  PetscReal, pointer :: soil_dx(:)           ! layer thickness of grid cell [m]
-  PetscReal, pointer :: soil_dy(:)           ! layer thickness of grid cell [m]
-  PetscReal, pointer :: soil_dz(:)           ! layer thickness of grid cell [m]
-  PetscReal, pointer :: soil_area(:)         ! area of grid cell [m^2]
-  PetscInt , pointer :: soil_filter(:)       ! 
-  
-  PetscInt, pointer  :: vert_conn_id_up(:)   !
-  PetscInt, pointer  :: vert_conn_id_dn(:)   !
-  PetscReal, pointer :: vert_conn_dist_up(:) !
-  PetscReal, pointer :: vert_conn_dist_dn(:) !
-  PetscReal, pointer :: vert_conn_area(:)    !
-  PetscInt , pointer :: vert_conn_type(:)    !
+    use MultiPhysicsProbConstants     , only : CONN_IN_Z_DIR, MESH_CLM_THERMAL_SOIL_COL
+    use mpp_varpar                    , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
+    use MeshType                      , only : mesh_type, MeshCreate
+    use mpp_varpar                    , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
+    use mesh_info
+    !
+    implicit none
+    !
+    class(mesh_type), pointer :: mesh
+    PetscInt                  :: imesh
+    PetscInt                  :: nlev
 
-  PetscErrorCode     :: ierr
+    call mpp_varpar_set_nlevsoi(nz)
+    call mpp_varpar_set_nlevgrnd(nz)
 
-  call mpp_varpar_set_nlevsoi(nz)
-  call mpp_varpar_set_nlevgrnd(nz)
+    imesh        = 1
+    nlev         = nz
+    ncells_local = nx*ny*nz
 
-  dx = x_column/nx
-  dy = y_column/ny
-  dz = z_column/nz
+    !
+    ! Set up the meshes
+    !
+    call thermal_enthalpy_mpp%SetNumMeshes(1)
 
-  imesh        = 1
-  nlev         = nz
-  ncells_local = nx*ny*nz
-  ncells_ghost = 0
+    allocate(mesh)
 
-  allocate(soil_xc(nz))
-  allocate(soil_yc(nz))
-  allocate(soil_zc(nz))
-  allocate(soil_dx(nz))
-  allocate(soil_dy(nz))
-  allocate(soil_dz(nz))
-  allocate(soil_area(nz))
-  allocate(soil_filter(nz))
-  
-  soil_filter (:) = 1
-  soil_area   (:) = dx*dy
-  soil_dx     (:) = dx
-  soil_dy     (:) = dy
-  soil_dz     (:) = dz
-  soil_xc     (:) = dx/2.d0
-  soil_xc     (:) = dy/2.d0
+    call MeshCreate(mesh, 'Soil mesh', x_column, y_column, z_column, &
+         nx, ny, nz, CONN_IN_Z_DIR)
+    call mesh%SetID(MESH_CLM_THERMAL_SOIL_COL)
 
-  do kk = 1,nz
-     soil_zc(kk) = dz/2.d0 + dz * (kk - 1)
-  enddo
-  
-  !
-  ! Set up the meshes
-  !    
-  call thermal_enthalpy_mpp%SetNumMeshes(1)
+    call thermal_enthalpy_mpp%AddMesh(imesh, mesh)
 
-  call thermal_enthalpy_mpp%MeshSetName        (imesh, 'Soil mesh')
-  call thermal_enthalpy_mpp%MeshSetOrientation (imesh, MESH_AGAINST_GRAVITY)
-  call thermal_enthalpy_mpp%MeshSetID          (imesh, MESH_CLM_THERMAL_SOIL_COL)
-  call thermal_enthalpy_mpp%MeshSetDimensions  (imesh, ncells_local, ncells_ghost, nlev)
+    call mesh%Clean()
 
-  call thermal_enthalpy_mpp%MeshSetGridCellFilter      (imesh, soil_filter)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_XC   , soil_xc)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_YC   , soil_yc)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_ZC   , soil_zc)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_DX   , soil_dx)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_DY   , soil_dy)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_DZ   , soil_dz)
-  call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_AREA , soil_area)
-  call thermal_enthalpy_mpp%MeshComputeVolume          (imesh)
-
-  allocate (vert_conn_id_up   (nz-1))
-  allocate (vert_conn_id_dn   (nz-1))
-  allocate (vert_conn_dist_up (nz-1))
-  allocate (vert_conn_dist_dn (nz-1))
-  allocate (vert_conn_area    (nz-1))
-  allocate (vert_conn_type    (nz-1))
-
-  iconn = 0
-  do kk = 1, nz-1
-
-     iconn = iconn + 1
-     vert_conn_id_up(iconn)   = kk
-     vert_conn_id_dn(iconn)   = vert_conn_id_up(iconn) + 1
-     vert_conn_dist_up(iconn) = 0.5d0*dz
-     vert_conn_dist_dn(iconn) = 0.5d0*dz
-     vert_conn_area(iconn)    = soil_area(kk)
-     vert_conn_type(iconn)    = CONN_VERTICAL
-
-  end do
-  vert_nconn = iconn
-
-  call thermal_enthalpy_mpp%MeshSetConnectionSet(imesh, CONN_SET_INTERNAL, &
-       vert_nconn,  vert_conn_id_up, vert_conn_id_dn,                      &
-       vert_conn_dist_up, vert_conn_dist_dn,  vert_conn_area,              &
-       vert_conn_type)
-  
-  deallocate(soil_xc)
-  deallocate(soil_yc)
-  deallocate(soil_zc)
-  deallocate(soil_dx)
-  deallocate(soil_dy)
-  deallocate(soil_dz)
-  deallocate(soil_area)
-  deallocate(soil_filter)  
+    deallocate(mesh)
 
 end subroutine add_meshes
 

--- a/src/driver/standalone/thermal-e/heat_transport_1D_problem.F90
+++ b/src/driver/standalone/thermal-e/heat_transport_1D_problem.F90
@@ -172,133 +172,37 @@ contains
 #include <petsc/finclude/petsc.h>
     !
     use MultiPhysicsProbThermalEnthalpy , only : thermal_enthalpy_mpp
-    use MultiPhysicsProbConstants       , only : MESH_ALONG_GRAVITY
-    use MultiPhysicsProbConstants       , only : MESH_AGAINST_GRAVITY
-    use MultiPhysicsProbConstants       , only : MESH_CLM_THERMAL_SOIL_COL
-    use MultiPhysicsProbConstants       , only : VAR_XC
-    use MultiPhysicsProbConstants       , only : VAR_YC
-    use MultiPhysicsProbConstants       , only : VAR_ZC
-    use MultiPhysicsProbConstants       , only : VAR_DX
-    use MultiPhysicsProbConstants       , only : VAR_DY
-    use MultiPhysicsProbConstants       , only : VAR_DZ
-    use MultiPhysicsProbConstants       , only : VAR_AREA
-    use MultiPhysicsProbConstants       , only : CONN_SET_INTERNAL
-    use MultiPhysicsProbConstants       , only : CONN_SET_LATERAL
-    use MultiPhysicsProbConstants       , only : CONN_VERTICAL
-    use mpp_varpar                      , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
-    use petscsys
+    use MultiPhysicsProbConstants , only : CONN_IN_Z_DIR
+    use mpp_varpar                , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
+    use MeshType                  , only : mesh_type, MeshCreate
     !
     implicit none
     !
-    PetscReal          :: dx, dy, dz
-    PetscInt           :: imesh, kk
-    PetscInt           :: nlev
-    PetscInt           :: iconn, vert_nconn
-    PetscReal, pointer :: soil_xc(:)           ! x-position of grid cell [m]
-    PetscReal, pointer :: soil_yc(:)           ! y-position of grid cell [m]
-    PetscReal, pointer :: soil_zc(:)           ! z-position of grid cell [m]
-    PetscReal, pointer :: soil_dx(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_dy(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_dz(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_area(:)         ! area of grid cell [m^2]
-    PetscInt , pointer :: soil_filter(:)       ! 
-
-    PetscInt, pointer  :: vert_conn_id_up(:)   !
-    PetscInt, pointer  :: vert_conn_id_dn(:)   !
-    PetscReal, pointer :: vert_conn_dist_up(:) !
-    PetscReal, pointer :: vert_conn_dist_dn(:) !
-    PetscReal, pointer :: vert_conn_area(:)    !
-    PetscInt , pointer :: vert_conn_type(:)    !
-
-    PetscErrorCode     :: ierr
+    class(mesh_type), pointer :: mesh
+    PetscInt                  :: imesh
+    PetscInt                  :: nlev
 
     call mpp_varpar_set_nlevsoi(nz)
     call mpp_varpar_set_nlevgrnd(nz)
 
-    dx = x_column/nx
-    dy = y_column/ny
-    dz = z_column/nz
-
     imesh        = 1
     nlev         = nz
-    ncells_local = nx*ny*nz
-    ncells_ghost = 0
-
-    allocate(soil_xc(nz))
-    allocate(soil_yc(nz))
-    allocate(soil_zc(nz))
-    allocate(soil_dx(nz))
-    allocate(soil_dy(nz))
-    allocate(soil_dz(nz))
-    allocate(soil_area(nz))
-    allocate(soil_filter(nz))
-
-    soil_filter (:) = 1
-    soil_area   (:) = dx*dy
-    soil_dx     (:) = dx
-    soil_dy     (:) = dy
-    soil_dz     (:) = dz
-    soil_xc     (:) = dx/2.d0
-    soil_xc     (:) = dy/2.d0
-
-    do kk = 1,nz
-       soil_zc(kk) = dz/2.d0 + dz * (kk - 1)
-    enddo
 
     !
     ! Set up the meshes
     !    
     call thermal_enthalpy_mpp%SetNumMeshes(1)
 
-    call thermal_enthalpy_mpp%MeshSetName        (imesh, 'Soil mesh')
-    call thermal_enthalpy_mpp%MeshSetOrientation (imesh, MESH_AGAINST_GRAVITY)
-    call thermal_enthalpy_mpp%MeshSetID          (imesh, MESH_CLM_THERMAL_SOIL_COL)
-    call thermal_enthalpy_mpp%MeshSetDimensions  (imesh, ncells_local, ncells_ghost, nlev)
+    allocate(mesh)
 
-    call thermal_enthalpy_mpp%MeshSetGridCellFilter      (imesh, soil_filter)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_XC   , soil_xc)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_YC   , soil_yc)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_ZC   , soil_zc)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_DX   , soil_dx)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_DY   , soil_dy)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_DZ   , soil_dz)
-    call thermal_enthalpy_mpp%MeshSetGeometricAttributes (imesh, VAR_AREA , soil_area)
-    call thermal_enthalpy_mpp%MeshComputeVolume          (imesh)
+    call MeshCreate(mesh, 'Soil mesh', x_column, y_column, z_column, &
+         nx, ny, nz, CONN_IN_Z_DIR)
 
-    allocate (vert_conn_id_up   (nz-1))
-    allocate (vert_conn_id_dn   (nz-1))
-    allocate (vert_conn_dist_up (nz-1))
-    allocate (vert_conn_dist_dn (nz-1))
-    allocate (vert_conn_area    (nz-1))
-    allocate (vert_conn_type    (nz-1))
+    call thermal_enthalpy_mpp%AddMesh(imesh, mesh)
 
-    iconn = 0
-    do kk = 1, nz-1
+    call mesh%Clean()
 
-       iconn = iconn + 1
-       vert_conn_id_up(iconn)   = kk
-       vert_conn_id_dn(iconn)   = vert_conn_id_up(iconn) + 1
-       vert_conn_dist_up(iconn) = 0.5d0*dz
-       vert_conn_dist_dn(iconn) = 0.5d0*dz
-       vert_conn_area(iconn)    = soil_area(kk)
-       vert_conn_type(iconn)    = CONN_VERTICAL
-
-    end do
-    vert_nconn = iconn
-
-    call thermal_enthalpy_mpp%MeshSetConnectionSet(imesh, CONN_SET_INTERNAL, &
-         vert_nconn,  vert_conn_id_up, vert_conn_id_dn,                      &
-         vert_conn_dist_up, vert_conn_dist_dn,  vert_conn_area,              &
-         vert_conn_type)
-
-    deallocate(soil_xc)
-    deallocate(soil_yc)
-    deallocate(soil_zc)
-    deallocate(soil_dx)
-    deallocate(soil_dy)
-    deallocate(soil_dz)
-    deallocate(soil_area)
-    deallocate(soil_filter)  
+    deallocate(mesh)
 
   end subroutine add_meshes
 

--- a/src/driver/standalone/thermal-e/heat_transport_1D_with_advection.F90
+++ b/src/driver/standalone/thermal-e/heat_transport_1D_with_advection.F90
@@ -354,7 +354,7 @@ subroutine add_conditions_to_goveqns()
   PetscReal                 , pointer :: area(:)
   PetscInt                  , pointer :: itype(:)
   PetscReal                 , pointer :: unit_vec(:,:)
-  type(connection_set_type) , pointer :: conn_set
+  class(connection_set_type) , pointer :: conn_set
   
   nconn         = 1
 

--- a/src/driver/standalone/thermal-e/th_manoli2014_problem.F90
+++ b/src/driver/standalone/thermal-e/th_manoli2014_problem.F90
@@ -827,7 +827,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_DIRICHLET_FRM_OTR_GOVEQ
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     !
     ! !ARGUMENTS
@@ -852,7 +851,7 @@ contains
     PetscReal                 , pointer :: area(:)
     PetscInt                  , pointer :: itype(:)
     PetscReal                 , pointer :: unit_vec(:,:)
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
 
     if (single_pde_formulation) return
 
@@ -964,7 +963,6 @@ contains
          icoupling_of_other_goveqns = icoupling_others, &
          conn_set=conn_set)
 
-    call ConnectionSetDestroy(conn_set)
     deallocate(ieqn_others     )
     deallocate(icoupling_others)
 
@@ -1031,7 +1029,6 @@ contains
          icoupling_of_other_goveqns = icoupling_others, &
          conn_set=conn_set)
 
-    call ConnectionSetDestroy(conn_set)
     deallocate(ieqn_others     )
     deallocate(icoupling_others)
 
@@ -1452,7 +1449,7 @@ contains
     type (rich_ode_pres_auxvar_type), pointer           :: aux_vars_bc(:)  !!< Boundary conditions.
     type (rich_ode_pres_auxvar_type), pointer           :: aux_vars_ss(:)  !!< Source-sink.
     type(condition_type),pointer                        :: cur_cond
-    type(connection_set_type), pointer                  :: cur_conn_set
+    class(connection_set_type), pointer                  :: cur_conn_set
     PetscInt                                            :: ghosted_id
     PetscInt                                            :: sum_conn
     PetscInt                                            :: iconn
@@ -1534,7 +1531,7 @@ contains
     type (rich_ode_pres_auxvar_type), pointer           :: aux_vars_bc(:)  !!< Boundary conditions.
     type (rich_ode_pres_auxvar_type), pointer           :: aux_vars_ss(:)  !!< Source-sink.
     type(condition_type),pointer                        :: cur_cond
-    type(connection_set_type), pointer                  :: cur_conn_set
+    class(connection_set_type), pointer                  :: cur_conn_set
     PetscInt                                            :: ghosted_id
     PetscInt                                            :: sum_conn
     PetscInt                                            :: iconn
@@ -1719,7 +1716,7 @@ contains
     type (therm_enthalpy_soil_auxvar_type)   , pointer   :: aux_vars_bc(:)
     type (therm_enthalpy_soil_auxvar_type)   , pointer   :: aux_vars_ss(:)
     type(condition_type)                     , pointer   :: cur_cond
-    type(connection_set_type)                , pointer   :: cur_conn_set
+    class(connection_set_type)                , pointer   :: cur_conn_set
     PetscInt                                             :: ghosted_id
     PetscInt                                             :: sum_conn
     PetscInt                                             :: iconn

--- a/src/driver/standalone/thermal/thermal_mms_steady_state_problem_1D.F90
+++ b/src/driver/standalone/thermal/thermal_mms_steady_state_problem_1D.F90
@@ -150,6 +150,7 @@ module thermal_mms_steady_state_problem_1D
         call compute_temperature_or_deriv(x,y,z,T=data_1D(count))
 
      case(DATA_HEAT_SOURCE)
+        jj = 1; kk = 1
         do ii = 1, nx
            x = soil_xc_3d(ii,1,1)
            y = soil_yc_3d(ii,jj,kk)

--- a/src/driver/standalone/vsfm/vsfm_manoli2014_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_manoli2014_problem.F90
@@ -824,7 +824,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_DIRICHLET_FRM_OTR_GOVEQ
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     !
     ! !ARGUMENTS
@@ -849,7 +848,7 @@ contains
     PetscReal                 , pointer :: area(:)
     PetscInt                  , pointer :: itype(:)
     PetscReal                 , pointer :: unit_vec(:,:)
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
 
     if (single_pde_formulation) return
 
@@ -920,8 +919,6 @@ contains
          id_of_other_goveqs = ieqn_others,                  &
          conn_set           = conn_set)
 
-    call ConnectionSetDestroy(conn_set)
-
     ieqn           = 2
     ieqn_others(1) = 1
 
@@ -939,8 +936,6 @@ contains
          id_of_other_goveqs = ieqn_others, &
          conn_set           = conn_set)
 
-    call ConnectionSetDestroy(conn_set)
-    
     ieqn           = 2
     ieqn_others(1) = 3
 
@@ -1104,7 +1099,7 @@ contains
     type (rich_ode_pres_auxvar_type), pointer           :: aux_vars_bc(:)  !!< Boundary conditions.
     type (rich_ode_pres_auxvar_type), pointer           :: aux_vars_ss(:)  !!< Source-sink.
     type(condition_type),pointer                        :: cur_cond
-    type(connection_set_type), pointer                  :: cur_conn_set
+    class(connection_set_type), pointer                  :: cur_conn_set
     PetscInt                                            :: ghosted_id
     PetscInt                                            :: sum_conn
     PetscInt                                            :: iconn

--- a/src/driver/standalone/vsfm/vsfm_spac_campbell_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_spac_campbell_problem.F90
@@ -743,7 +743,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_DOWNREG_MASS_RATE_CAMPBELL
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     use petscsys
     !
@@ -764,7 +763,7 @@ contains
     PetscInt                            :: num_other_goveqs
     PetscInt                  , pointer :: ieqn_others(:)
 
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
 
     ieqn       = 1
     call vsfm_mpp%soe%AddConditionInGovEqn(ieqn, COND_SS,   &
@@ -880,8 +879,6 @@ contains
          id_of_other_goveqs = ieqn_others                  , &
          conn_set           = conn_set)
 
-
-    call ConnectionSetDestroy(conn_set)
 
     deallocate(id_up    )
     deallocate(id_dn    )

--- a/src/driver/standalone/vsfm/vsfm_spac_fetch2_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_spac_fetch2_problem.F90
@@ -1,30 +1,60 @@
 module vsfm_spac_fetch2_problem
 
+#include <petsc/finclude/petsc.h>
+
+  use petscsys
+  use petscvec
+  use petscmat
+  use petscts
+  use petscsnes
+  use petscdm
+  use petscdmda
+
   implicit none
 
-#include <petsc/finclude/petsc.h>
-  PetscInt  , parameter :: nx       = 1           ! -
-  PetscInt  , parameter :: ny       = 1           ! -
-  PetscInt  , parameter :: nz       = 60           ! -
-  PetscReal , parameter :: Az       = 9.8715e-3   ! m^2
-  !PetscReal , parameter :: dx       = 9.8715e-3   ! m
-  PetscReal , parameter :: dx       = 0.0088d0    ! m
-  PetscReal , parameter :: porosity = 0.55d0      ! -
-  PetscReal , parameter :: dy       = 1.d0        ! m
-  PetscReal , parameter :: dz       = 0.2d0       ! m
-  PetscReal , parameter :: Acrown   = 28.8415d0   ! m^2
-  PetscReal , parameter :: phis50   = -1.0d6      ! Pa
-  PetscReal , parameter :: phi50    = -2.1048d6   ! Pa
-  PetscReal , parameter :: phi88    = -0.5876d6   ! Pa
-  PetscReal , parameter :: c1       = 1.278d6     ! Pa
-  PetscReal , parameter :: c2       = 2.8299d0    ! -
-  PetscReal , parameter :: c3       = 5.d0        ! -
-  PetscReal , parameter :: kmax     = 9.8513d-7   ! s
-  PetscReal , parameter :: vis      = 8.904156d-4 ! Pa s
-  PetscReal , parameter :: rho      = 1000.d0     ! kg m^{-3}
-  PetscReal , parameter :: grav     = 9.81        ! m s^{-2}
+  PetscReal , parameter :: vis      = 8.904156d-4   ! Pa s
+  PetscReal , parameter :: rho      = 1000.d0       ! kg m^{-3}
+  PetscReal , parameter :: grav     = 9.81          ! m s^{-2}
+
+  PetscInt  , parameter :: nx       = 1             ! -
+  PetscInt  , parameter :: ny       = 1             ! -
+  PetscReal , parameter :: dx       = 1.d0          ! m
+  PetscReal , parameter :: dy       = 1.d0          ! m
+  PetscReal , parameter :: dz       = 0.2d0         ! m
+
+  PetscReal , parameter :: porosity = 0.55d0        ! [-]
+
+  PetscInt  , parameter :: oak_nz       = 60        ! -
+  PetscReal , parameter :: oak_Asapwood = 0.0088d0  ! m^2
+  PetscReal , parameter :: oak_Acrown   = 28.8d0    ! m^2
+  PetscReal , parameter :: oak_phis50   = -0.91d6   ! Pa
+  PetscReal , parameter :: oak_phi50    = -2.5d6    ! Pa
+  PetscReal , parameter :: oak_phi88    = -0.5d6    ! Pa
+  PetscReal , parameter :: oak_c1       = 1.7d6     ! Pa
+  PetscReal , parameter :: oak_c2       = 3.0d0     ! -
+  PetscReal , parameter :: oak_c3       = 12.3d0    ! -
+  PetscReal , parameter :: oak_kmax     = 1.6d-6    ! s
+
+  PetscInt  , parameter :: pine_nz       = 85       ! -
+  PetscReal , parameter :: pine_Asapwood = 0.0616d0 ! m^2
+  PetscReal , parameter :: pine_Acrown   = 46.1d0   ! m^2
+  !PetscReal , parameter :: pine_phis50   = -0.18d6  ! Pa
+  PetscReal , parameter :: pine_phis50   = -0.91d6  ! Pa
+  PetscReal , parameter :: pine_phi50    = -2.2d6   ! Pa
+  PetscReal , parameter :: pine_phi88    = -0.5d6   ! Pa
+  PetscReal , parameter :: pine_c1       = 1.2d6    ! Pa
+  PetscReal , parameter :: pine_c2       = 2.8d0    ! -
+  PetscReal , parameter :: pine_c3       = 10.3d0   ! -
+  PetscReal , parameter :: pine_kmax     = 1.2d-6   ! s
+
+  character(len=256) :: problem_type
+
+  character(len=256) :: ic_filename
+  PetscBool          :: ic_file_specified
+
   PetscInt              :: ncells_local
   PetscInt              :: ncells_ghost
+
   PetscReal             :: theta_s
   PetscReal             :: VG_alpha
   PetscReal             :: VG_n
@@ -36,22 +66,15 @@ contains
 
   subroutine run_vsfm_spac_fetch2_problem()
     !
-#include <petsc/finclude/petsc.h>
     !
     use MultiPhysicsProbVSFM , only : vsfm_mpp
     use mpp_varpar           , only : mpp_varpar_init
-    use petscsys
-    use petscvec
-    use petscmat
-    use petscts
-    use petscsnes
-    use petscdm
-    use petscdmda
     !
     implicit none
     !
     PetscBool          :: converged
     PetscInt           :: converged_reason
+    PetscInt           :: nz
     PetscErrorCode     :: ierr
     PetscReal          :: dtime
     PetscReal          :: time
@@ -66,8 +89,11 @@ contains
     Vec                :: ET
     Vec                :: SoilBC
     Vec                :: Actual_ET
+    PetscInt           :: vec_size
+    PetscInt           :: ntimes
     PetscReal, pointer :: act_et_p(:)
     PetscViewer        :: viewer
+    PetscBool          :: error_in_cmd_options
 
     ! Set default settings
     dtime                  = 180.d0
@@ -75,6 +101,9 @@ contains
     save_initial_soln      = PETSC_FALSE
     save_final_soln        = PETSC_FALSE
     print_actual_et        = PETSC_FALSE
+    error_in_cmd_options   = PETSC_FALSE
+    problem_type           = 'oak'
+    ic_file_specified      = PETSC_FALSE
 
     ! Get some command line options
 
@@ -87,41 +116,92 @@ contains
     call PetscOptionsGetBool (PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
          '-save_final_soln', save_final_soln, flg,ierr)
 
-    call PetscOptionsGetBool (PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
-         '-print_actual_et', print_actual_et, flg, ierr)
-
     call PetscOptionsGetString (PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
          '-pet_file', pet_file, flg, ierr)
     if (.not.flg) then
-       write(*,*)'Need to specify the potential ET filename using -pet_file'
-       stop
+       write(*,*)'ERROR: Specify the potential ET filename via -pet_file <filename>'
+       error_in_cmd_options = PETSC_TRUE
     end if
 
     call PetscOptionsGetString (PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
          '-soil_bc_file',soil_bc_file,flg,ierr)
     if (.not.flg) then
-       write(*,*)'Need to specify the soil boundary condition filename using -soil_bc_file'
-       stop
+       write(*,*)'ERROR: Specify the soil boundary condition filename via -soil_bc_file <filename>'
+       error_in_cmd_options = PETSC_TRUE
     end if
     
     call PetscOptionsGetString (PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
          '-actual_et_file', actual_et_file, flg, ierr)
-    if (.not.flg .and. print_actual_et) then
-       write(*,*)'Need to specify the output filename for actual ET using -actual_et_file'
+    if (flg) then
+       print_actual_et = PETSC_TRUE
+    end if
+
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
+         '-ic_file', ic_filename, flg, ierr)
+    if (flg) ic_file_specified = PETSC_TRUE
+
+    call PetscOptionsGetString (PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, &
+         '-problem_type', problem_type, flg, ierr)
+    if (flg) then
+       select case(trim(problem_type))
+       case ('oak')
+       case ('pine')
+       case ('oak_and_pine')
+       case default
+          write(*,*)'ERROR: Unknown option specified via -problem_type <value>.'
+          write(*,*)'       Valid value for -problem_type are:'
+          write(*,*)'         oak'
+          write(*,*)'         pine'
+          write(*,*)'         oak_and_pine'
+          error_in_cmd_options = PETSC_TRUE
+       end select
+    end if
+
+    if (error_in_cmd_options) stop
+
+    select case(trim(problem_type))
+    case ('oak')
+       nz       = oak_nz
+    case ('pine')
+       nz       = pine_nz
+    case ('oak_and_pine')
+       nz       = oak_nz + pine_nz
+    case default
+       write(*,*)'Unsupported problem_type'
+       stop
+    end select
+
+    ! Read the PET file
+    call PetscViewerBinaryOpen(PETSC_COMM_WORLD, pet_file, FILE_MODE_READ, viewer, ierr); CHKERRQ(ierr)
+    call VecCreate(PETSC_COMM_WORLD, ET, ierr); CHKERRQ(ierr)
+    call VecLoad(ET, viewer, ierr); CHKERRQ(ierr)
+    call PetscViewerDestroy(viewer, ierr); CHKERRQ(ierr)
+    call VecGetSize(ET, vec_size, ierr); CHKERRQ(ierr)
+
+    ntimes = vec_size/nz
+    if (nstep > ntimes) then
+       write(*,*)'ERROR: Value for nstep exceeds the number of timesteps ' // &
+            'for which potential ET data is available.'
+       write(*,*)'nstep = ',nstep
+       write(*,*)'ntimes= ',ntimes
        stop
     end if
 
-    ! Read the PET file
-    call PetscViewerBinaryOpen(PETSC_COMM_WORLD, pet_file, FILE_MODE_READ, viewer, ierr)
-    call VecCreate(PETSC_COMM_WORLD, ET, ierr)
-    call VecLoad(ET, viewer, ierr)
-    call PetscViewerDestroy(viewer, ierr)
-
     ! Read the soil bc file
-    call PetscViewerBinaryOpen(PETSC_COMM_WORLD, soil_bc_file, FILE_MODE_READ, viewer, ierr)
-    call VecCreate(PETSC_COMM_WORLD, SoilBC, ierr)
-    call VecLoad(SoilBC, viewer, ierr)
-    call PetscViewerDestroy(viewer, ierr)
+    call PetscViewerBinaryOpen(PETSC_COMM_WORLD, soil_bc_file, FILE_MODE_READ, viewer, ierr); CHKERRQ(ierr)
+    call VecCreate(PETSC_COMM_WORLD, SoilBC, ierr); CHKERRQ(ierr)
+    call VecLoad(SoilBC, viewer, ierr); CHKERRQ(ierr)
+    call PetscViewerDestroy(viewer, ierr); CHKERRQ(ierr)
+    call VecGetSize(SoilBC, vec_size, ierr); CHKERRQ(ierr)
+
+    ntimes = vec_size
+    if (nstep > ntimes) then
+       write(*,*)'ERROR: Value for nstep exceeds the number of timesteps ' // &
+            'for which soil boundary condition data is available.'
+       write(*,*)'nstep = ',nstep
+       write(*,*)'ntimes= ',ntimes
+       stop
+    end if
 
     ! Initialize the problem
     call Init()
@@ -130,9 +210,24 @@ contains
     call VecCreateSeq(PETSC_COMM_SELF, nstep*nz, Actual_ET, ierr)
     call VecGetArrayF90(Actual_ET, act_et_p, ierr)
 
+    call PetscViewerBinaryOpen(PETSC_COMM_SELF,'init.bin',FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
+    call VecView(vsfm_mpp%soe%solver%soln,viewer,ierr);CHKERRQ(ierr)
+    call PetscViewerDestroy(viewer,ierr);CHKERRQ(ierr)
+
     do istep = 1, nstep
 
-       call set_bondary_conditions(istep, ET, SoilBC)
+       select case(trim(problem_type))
+       case ('oak')
+          call set_bondary_conditions_for_single_tree(nz, istep, ET, SoilBC)
+       case ('pine')
+          call set_bondary_conditions_for_single_tree(nz, istep, ET, SoilBC)
+       case ('oak_and_pine')
+          call set_bondary_conditions_for_two_trees(nz, istep, ET, SoilBC)
+       case default
+          write(*,*)'Unsupported problem_type'
+          stop
+       end select
+
        time = time + dtime
 
        ! Run the model
@@ -144,10 +239,26 @@ contains
           stop
        end if
 
-       if (print_actual_et) call diagnose_actual_sink(istep, act_et_p)
+       if (print_actual_et) then
+          select case(trim(problem_type))
+          case ('oak')
+             call diagnose_actual_sink_for_single_tree(nz, istep, act_et_p)
+          case ('pine')
+             call diagnose_actual_sink_for_single_tree(nz, istep, act_et_p)
+          case ('oak_and_pine')
+             call diagnose_actual_sink_for_single_tree(nz, istep, act_et_p)
+          case default
+             write(*,*)'Unsupported problem_type'
+             stop
+          end select
+       end if
 
     end do
     call VecRestoreArrayF90(Actual_ET, act_et_p, ierr)
+
+    call PetscViewerBinaryOpen(PETSC_COMM_SELF,'final.bin',FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
+    call VecView(vsfm_mpp%soe%solver%soln,viewer,ierr);CHKERRQ(ierr)
+    call PetscViewerDestroy(viewer,ierr);CHKERRQ(ierr)
 
     if (print_actual_et) then
        call PetscViewerBinaryOpen(PETSC_COMM_SELF,actual_et_file,FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
@@ -173,13 +284,33 @@ contains
     call initialize_mpp()
 
     ! 2. Add all meshes needed for the MPP
-    call add_mesh()
+    select case(trim(problem_type))
+    case ('oak')
+       call add_mesh_for_single_tree(oak_nz, oak_Asapwood)
+    case ('pine')
+       call add_mesh_for_single_tree(pine_nz, pine_Asapwood)
+    case ('oak_and_pine')
+       call add_mesh_for_two_trees()
+    case default
+       write(*,*)'Unsupported problem_type'
+       stop
+    end select
 
     ! 3. Add all governing equations
     call add_goveqn()
 
     ! 4. Add boundary and source-sink conditions to all governing equations
-    call add_conditions_to_goveqns()
+    select case(trim(problem_type))
+    case ('oak')
+       call add_conditions_to_goveqns_for_single_tree()
+    case ('pine')
+       call add_conditions_to_goveqns_for_single_tree()
+    case ('oak_and_pine')
+       call add_conditions_to_goveqns_for_two_trees()
+    case default
+       write(*,*)'Unsupported problem_type'
+       stop
+    end select
 
     ! 5. Allocate memory to hold auxvars
     call allocate_auxvars()
@@ -188,10 +319,32 @@ contains
     call vsfm_mpp%SetupProblem()
 
     ! 7. Add material properities associated with all governing equations
-    call set_material_properties() 
+    select case(trim(problem_type))
+    case ('oak')
+       call set_material_properties_for_single_tree(oak_nz, porosity, oak_phi88, oak_phi50, &
+            oak_kmax, oak_c1, oak_c2, oak_c3, oak_phis50)
+    case ('pine')
+       call set_material_properties_for_single_tree(pine_nz, porosity, pine_phi88, pine_phi50, &
+            pine_kmax, pine_c1, pine_c2, pine_c3, pine_phis50)
+    case ('oak_and_pine')
+       call set_material_properties_for_two_trees()
+    case default
+       write(*,*)'Unsupported problem_type'
+       stop
+    end select
 
     ! 8. Set initial conditions
-    call set_initial_conditions()
+    select case(trim(problem_type))
+    case ('oak')
+       call set_initial_conditions_for_single_tree(oak_nz)
+    case ('pine')
+       call set_initial_conditions_for_single_tree(pine_nz)
+    case ('oak_and_pine')
+       call set_initial_conditions_for_two_trees()
+    case default
+       write(*,*)'Unsupported problem_type'
+       stop
+    end select
 
   end subroutine Init
 
@@ -227,13 +380,14 @@ contains
   end subroutine initialize_mpp
 
   !------------------------------------------------------------------------
-  subroutine add_mesh()
+  subroutine add_mesh_for_single_tree(local_nz, local_Asapwood)
     !
     use MultiPhysicsProbVSFM      , only : vsfm_mpp
     use MultiPhysicsProbConstants , only : MESH_ALONG_GRAVITY
     use MultiPhysicsProbConstants , only : MESH_AGAINST_GRAVITY
     use MultiPhysicsProbConstants , only : MESH_CLM_SOIL_COL
     use MultiPhysicsProbConstants , only : VAR_XC
+    
     use MultiPhysicsProbConstants , only : VAR_YC
     use MultiPhysicsProbConstants , only : VAR_ZC
     use MultiPhysicsProbConstants , only : VAR_DX
@@ -248,7 +402,9 @@ contains
     !
     implicit none
     !
-#include <petsc/finclude/petsc.h>
+    PetscInt            :: local_nz
+    PetscReal           :: local_Asapwood
+
     !
     PetscInt            :: imesh, kk
     PetscInt            :: nlev
@@ -278,7 +434,7 @@ contains
     PetscErrorCode      :: ierr
 
     ncells_ghost = 0
-    ncells_xylem = nz
+    ncells_xylem =local_nz
 
     allocate(xc_xylem     (ncells_xylem ))
     allocate(yc_xylem     (ncells_xylem ))
@@ -291,23 +447,22 @@ contains
     allocate(vol_xylem    (ncells_xylem ))
     
     filter_xylem (:) = 1
-    area_xylem   (:) = dx * dy
-    dx_xylem     (:) = dx
-    dy_xylem     (:) = dy
+    area_xylem   (:) = local_Asapwood
+    dx_xylem     (:) = sqrt(local_Asapwood)
+    dy_xylem     (:) = sqrt(local_Asapwood)
     dz_xylem     (:) = dz
-    xc_xylem     (:) = dx/2.d0
-    yc_xylem     (:) = dy/2.d0
-    vol_xylem    (:) = 1.d0/50.d0
+    xc_xylem     (:) = sqrt(local_Asapwood)/2.d0
+    yc_xylem     (:) = sqrt(local_Asapwood)/2.d0
 
-    zc_xylem(1)  = 0.17d0
+    zc_xylem(1)  = -0.17d0 + local_nz * dz
     vol_xylem(1) = area_xylem(1) * dz
-    do kk = 2, nz
-       zc_xylem(kk)  = -(dz/2.d0 + dz * (kk - 1))
+    do kk = 2, local_nz
+       zc_xylem(kk)  = -(dz/2.d0 + dz * (kk - 1)) + local_nz * dz
        vol_xylem(kk) = area_xylem(kk) * dz
     enddo
 
-    call mpp_varpar_set_nlevsoi(nz)
-    call mpp_varpar_set_nlevgrnd(nz)
+    call mpp_varpar_set_nlevsoi(local_nz)
+    call mpp_varpar_set_nlevgrnd(local_nz)
 
     !
     ! Set up the meshes
@@ -319,7 +474,7 @@ contains
     call vsfm_mpp%MeshSetName                (imesh, 'Xylem mesh')
     call vsfm_mpp%MeshSetOrientation         (imesh, MESH_ALONG_GRAVITY)
     call vsfm_mpp%MeshSetID                  (imesh, MESH_CLM_SOIL_COL)
-    call vsfm_mpp%MeshSetDimensions          (imesh, ncells_xylem, ncells_ghost, nz)
+    call vsfm_mpp%MeshSetDimensions          (imesh, ncells_xylem, ncells_ghost, local_nz)
 
     call vsfm_mpp%MeshSetGridCellFilter      (imesh, filter_xylem)
     call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_XC     , xc_xylem)
@@ -331,7 +486,7 @@ contains
     call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_AREA   , area_xylem)
     call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_VOLUME , vol_xylem)
 
-    nconn_xylem = nz - 1
+    nconn_xylem = local_nz - 1
 
     allocate (vert_conn_id_up_xylem   (nconn_xylem))
     allocate (vert_conn_id_dn_xylem   (nconn_xylem))
@@ -341,7 +496,7 @@ contains
     allocate (vert_conn_type_xylem    (nconn_xylem))
 
     iconn = 0
-    do kk = 1, nz - 1
+    do kk = 1, local_nz - 1
        iconn = iconn + 1
        vert_conn_id_up_xylem(iconn)   = kk 
        vert_conn_id_dn_xylem(iconn)   = kk + 1
@@ -374,7 +529,175 @@ contains
     deallocate (vert_conn_area_xylem    )
     deallocate (vert_conn_type_xylem    )
 
-  end subroutine add_mesh
+  end subroutine add_mesh_for_single_tree
+
+  !------------------------------------------------------------------------
+
+  subroutine add_mesh_for_two_trees()
+    !
+    use MultiPhysicsProbVSFM      , only : vsfm_mpp
+    use MultiPhysicsProbConstants , only : MESH_ALONG_GRAVITY
+    use MultiPhysicsProbConstants , only : MESH_AGAINST_GRAVITY
+    use MultiPhysicsProbConstants , only : MESH_CLM_SOIL_COL
+    use MultiPhysicsProbConstants , only : VAR_XC
+    
+    use MultiPhysicsProbConstants , only : VAR_YC
+    use MultiPhysicsProbConstants , only : VAR_ZC
+    use MultiPhysicsProbConstants , only : VAR_DX
+    use MultiPhysicsProbConstants , only : VAR_DY
+    use MultiPhysicsProbConstants , only : VAR_DZ
+    use MultiPhysicsProbConstants , only : VAR_AREA
+    use MultiPhysicsProbConstants , only : VAR_VOLUME
+    use MultiPhysicsProbConstants , only : CONN_SET_INTERNAL
+    use MultiPhysicsProbConstants , only : CONN_SET_LATERAL
+    use MultiPhysicsProbConstants , only : CONN_VERTICAL
+    use mpp_varpar                , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
+    !
+    implicit none
+    !
+
+    !
+    PetscInt            :: imesh, kk
+    PetscInt            :: nlev
+    PetscInt            :: iconn, vert_nconn
+
+    PetscInt            :: ncells_xylem
+
+    PetscInt            :: nconn_xylem
+
+    PetscReal , pointer :: xc_xylem(:)                ! x-position of grid cell [m]
+    PetscReal , pointer :: yc_xylem(:)                ! y-position of grid cell [m]
+    PetscReal , pointer :: zc_xylem(:)                ! z-position of grid cell [m]
+    PetscReal , pointer :: dx_xylem(:)                ! layer thickness of grid cell [m]
+    PetscReal , pointer :: dy_xylem(:)                ! layer thickness of grid cell [m]
+    PetscReal , pointer :: dz_xylem(:)                ! layer thickness of grid cell [m]
+    PetscReal , pointer :: area_xylem(:)              ! area of grid cell [m^2]
+    PetscReal , pointer :: vol_xylem(:)               ! volume of grid cell [m^3]
+    PetscInt  , pointer :: filter_xylem(:)            ! 
+    
+    PetscInt  , pointer :: vert_conn_id_up_xylem(:)   !
+    PetscInt  , pointer :: vert_conn_id_dn_xylem(:)   !
+    PetscReal , pointer :: vert_conn_dist_up_xylem(:) !
+    PetscReal , pointer :: vert_conn_dist_dn_xylem(:) !
+    PetscReal , pointer :: vert_conn_area_xylem(:)    !
+    PetscInt  , pointer :: vert_conn_type_xylem(:)    !
+
+    PetscErrorCode      :: ierr
+
+    ncells_ghost = 0
+    ncells_xylem = oak_nz + pine_nz
+
+    allocate(xc_xylem     (ncells_xylem ))
+    allocate(yc_xylem     (ncells_xylem ))
+    allocate(zc_xylem     (ncells_xylem ))
+    allocate(dx_xylem     (ncells_xylem ))
+    allocate(dy_xylem     (ncells_xylem ))
+    allocate(dz_xylem     (ncells_xylem ))
+    allocate(area_xylem   (ncells_xylem ))
+    allocate(filter_xylem (ncells_xylem ))
+    allocate(vol_xylem    (ncells_xylem ))
+    
+    filter_xylem (:) = 1
+    area_xylem   (1:oak_nz) = oak_Asapwood            ;area_xylem   (oak_nz+1:oak_nz+pine_nz) = pine_Asapwood;
+    dx_xylem     (1:oak_nz) = sqrt(oak_Asapwood)      ;dx_xylem     (oak_nz+1:oak_nz+pine_nz) = sqrt(pine_Asapwood);
+    dy_xylem     (1:oak_nz) = sqrt(oak_Asapwood)      ;dy_xylem     (oak_nz+1:oak_nz+pine_nz) = sqrt(pine_Asapwood);
+    dz_xylem     (:) = dz
+    xc_xylem     (1:oak_nz) = sqrt(oak_Asapwood)/2.d0 ;xc_xylem     (oak_nz+1:oak_nz+pine_nz) = sqrt(pine_Asapwood)/2.d0;
+    yc_xylem     (1:oak_nz) = sqrt(oak_Asapwood)/2.d0 ;yc_xylem     (oak_nz+1:oak_nz+pine_nz) = sqrt(pine_Asapwood)/2.d0;
+
+    zc_xylem(1)  = 0.17d0 + oak_nz * dz
+    vol_xylem(1) = area_xylem(1) * dz
+    do kk = 2, oak_nz
+       zc_xylem(kk)  = -(dz/2.d0 + dz * (kk - 1)) + oak_nz * dz
+       vol_xylem(kk) = area_xylem(kk) * dz
+    enddo
+
+    zc_xylem(oak_nz+1)  = 0.17d0 + pine_nz * dz
+    vol_xylem(oak_nz+1) = area_xylem(oak_nz+1) * dz
+    do kk = oak_nz+2, oak_nz+pine_nz
+       zc_xylem(kk)  = -(dz/2.d0 + dz * (kk - 1-oak_nz)) + pine_nz * dz
+       vol_xylem(kk) = area_xylem(kk) * dz
+    enddo
+
+    call mpp_varpar_set_nlevsoi(oak_nz + pine_nz)
+    call mpp_varpar_set_nlevgrnd(oak_nz+ pine_nz)
+
+    !
+    ! Set up the meshes
+    !    
+    call vsfm_mpp%SetNumMeshes(1)
+
+    ! Xylem Mesh
+    imesh        = 1
+    call vsfm_mpp%MeshSetName                (imesh, 'Xylem mesh')
+    call vsfm_mpp%MeshSetOrientation         (imesh, MESH_ALONG_GRAVITY)
+    call vsfm_mpp%MeshSetID                  (imesh, MESH_CLM_SOIL_COL)
+    call vsfm_mpp%MeshSetDimensions          (imesh, ncells_xylem, ncells_ghost, oak_nz + pine_nz)
+
+    call vsfm_mpp%MeshSetGridCellFilter      (imesh, filter_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_XC     , xc_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_YC     , yc_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_ZC     , zc_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DX     , dx_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DY     , dy_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DZ     , dz_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_AREA   , area_xylem)
+    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_VOLUME , vol_xylem)
+
+    nconn_xylem = oak_nz - 1 + pine_nz - 1
+
+    allocate (vert_conn_id_up_xylem   (nconn_xylem))
+    allocate (vert_conn_id_dn_xylem   (nconn_xylem))
+    allocate (vert_conn_dist_up_xylem (nconn_xylem))
+    allocate (vert_conn_dist_dn_xylem (nconn_xylem))
+    allocate (vert_conn_area_xylem    (nconn_xylem))
+    allocate (vert_conn_type_xylem    (nconn_xylem))
+
+    iconn = 0
+    do kk = 1, oak_nz - 1
+       iconn = iconn + 1
+       vert_conn_id_up_xylem(iconn)   = kk 
+       vert_conn_id_dn_xylem(iconn)   = kk + 1
+       vert_conn_dist_up_xylem(iconn) = 0.5d0*dz
+       vert_conn_dist_dn_xylem(iconn) = 0.5d0*dz
+       vert_conn_area_xylem(iconn)    = area_xylem(kk)
+       vert_conn_type_xylem(iconn)    = CONN_VERTICAL
+    end do
+
+    do kk = oak_nz + 1, oak_nz + pine_nz - 1
+       iconn = iconn + 1
+       vert_conn_id_up_xylem(iconn)   = kk 
+       vert_conn_id_dn_xylem(iconn)   = kk + 1
+       vert_conn_dist_up_xylem(iconn) = 0.5d0*dz
+       vert_conn_dist_dn_xylem(iconn) = 0.5d0*dz
+       vert_conn_area_xylem(iconn)    = area_xylem(kk)
+       vert_conn_type_xylem(iconn)    = CONN_VERTICAL
+    end do
+
+    imesh = 1
+    call vsfm_mpp%MeshSetConnectionSet(imesh, CONN_SET_INTERNAL, &
+         nconn_xylem,  vert_conn_id_up_xylem, vert_conn_id_dn_xylem,          &
+         vert_conn_dist_up_xylem, vert_conn_dist_dn_xylem,  vert_conn_area_xylem,  &
+         vert_conn_type_xylem)
+
+    deallocate (xc_xylem                )
+    deallocate (yc_xylem                )
+    deallocate (zc_xylem                )
+    deallocate (dx_xylem                )
+    deallocate (dy_xylem                )
+    deallocate (dz_xylem                )
+    deallocate (area_xylem              )
+    deallocate (filter_xylem            )
+    deallocate (vol_xylem               )
+
+    deallocate (vert_conn_id_up_xylem   )
+    deallocate (vert_conn_id_dn_xylem   )
+    deallocate (vert_conn_dist_up_xylem )
+    deallocate (vert_conn_dist_dn_xylem )
+    deallocate (vert_conn_area_xylem    )
+    deallocate (vert_conn_type_xylem    )
+
+  end subroutine add_mesh_for_two_trees
 
   !------------------------------------------------------------------------
 
@@ -384,7 +707,7 @@ contains
     !
     !
     ! !USES:
-    use MultiPhysicsProbVSFM , only : vsfm_mpp
+    use MultiPhysicsProbVSFM      , only : vsfm_mpp
     use MultiPhysicsProbConstants , only : GE_RE
     use MultiPhysicsProbConstants , only : MESH_CLM_SOIL_COL
     !
@@ -398,7 +721,7 @@ contains
   end subroutine add_goveqn
 
   !------------------------------------------------------------------------
-  subroutine add_conditions_to_goveqns()
+  subroutine add_conditions_to_goveqns_for_single_tree()
     !
     ! !DESCRIPTION:
     !
@@ -431,7 +754,98 @@ contains
     call vsfm_mpp%soe%AddConditionInGovEqn(ieqn, COND_BC,   &
          'Bottom BC', 'Pa', COND_DIRICHLET, SOIL_BOTTOM_CELLS)
 
-  end subroutine add_conditions_to_goveqns
+  end subroutine add_conditions_to_goveqns_for_single_tree
+
+  !------------------------------------------------------------------------
+  subroutine add_conditions_to_goveqns_for_two_trees()
+    !
+    ! !DESCRIPTION:
+    !
+    !
+    ! !USES:
+    use MultiPhysicsProbVSFM      , only : vsfm_mpp
+    use MultiPhysicsProbConstants , only : ALL_CELLS
+    use MultiPhysicsProbConstants , only : SOIL_TOP_CELLS
+    use MultiPhysicsProbConstants , only : SOIL_BOTTOM_CELLS
+    use MultiPhysicsProbConstants , only : COND_BC
+    use MultiPhysicsProbConstants , only : COND_SS
+    use MultiPhysicsProbConstants , only : COND_DIRICHLET
+    use MultiPhysicsProbConstants , only : COND_DOWNREG_MASS_RATE_FETCH2
+    use MultiPhysicsProbConstants , only : CONN_VERTICAL
+    use ConnectionSetType         , only : connection_set_type
+    use MeshType                  , only : MeshCreateConnectionSet
+    use petscsys
+    !
+    ! !ARGUMENTS
+    implicit none
+    !
+    PetscInt                            :: ieqn
+    PetscInt                            :: nconn
+    PetscInt                            :: iconn
+    PetscInt                  , pointer :: conn_id_up(:)
+    PetscInt                  , pointer :: conn_id_dn(:)
+    PetscReal                 , pointer :: conn_dist_up(:)
+    PetscReal                 , pointer :: conn_dist_dn(:)
+    PetscReal                 , pointer :: conn_area(:)
+    PetscInt                  , pointer :: conn_type(:)
+    PetscReal                 , pointer :: conn_unitvec(:,:)
+    class(connection_set_type), pointer :: conn_set
+
+    ieqn       = 1
+    call vsfm_mpp%soe%AddConditionInGovEqn(ieqn, COND_SS,   &
+         'Potential Mass_Flux', 'kg/s', COND_DOWNREG_MASS_RATE_FETCH2, &
+         ALL_CELLS)
+
+    nconn = 2
+
+    allocate (conn_id_up   (nconn))
+    allocate (conn_id_dn   (nconn))
+    allocate (conn_dist_up (nconn))
+    allocate (conn_dist_dn (nconn))
+    allocate (conn_area    (nconn))
+    allocate (conn_type    (nconn))
+    allocate (conn_unitvec (nconn,3))
+
+    iconn = 1
+    conn_id_up(iconn)     = 0
+    conn_id_dn(iconn)     = oak_nz
+    conn_dist_up(iconn)   = 0.d0
+    conn_dist_dn(iconn)   = 0.5d0*dz
+    conn_area(iconn)      = oak_Asapwood
+    conn_type(iconn)      = CONN_VERTICAL
+    conn_unitvec(iconn,1) = 0.d0
+    conn_unitvec(iconn,2) = 0.d0
+    conn_unitvec(iconn,3) = 1.d0
+
+    iconn = 2
+    conn_id_up(iconn)     = 0
+    conn_id_dn(iconn)     = oak_nz+pine_nz
+    conn_dist_up(iconn)   = 0.d0
+    conn_dist_dn(iconn)   = 0.5d0*dz
+    conn_area(iconn)      = pine_Asapwood
+    conn_type(iconn)      = CONN_VERTICAL
+    conn_unitvec(iconn,1) = 0.d0
+    conn_unitvec(iconn,2) = 0.d0
+    conn_unitvec(iconn,3) = 1.d0
+
+    call MeshCreateConnectionSet(vsfm_mpp%meshes(1), &
+         nconn, conn_id_up, conn_id_dn, &
+         conn_dist_up, conn_dist_dn, conn_area, &
+         conn_type, conn_unitvec, conn_set)
+
+    ieqn       = 1
+    call vsfm_mpp%soe%AddConditionInGovEqn(ieqn, COND_BC,   &
+         'Bottom BC', 'Pa', COND_DIRICHLET, SOIL_BOTTOM_CELLS, conn_set)
+
+    deallocate (conn_id_up   )
+    deallocate (conn_id_dn   )
+    deallocate (conn_dist_up )
+    deallocate (conn_dist_dn )
+    deallocate (conn_area    )
+    deallocate (conn_type    )
+    deallocate (conn_unitvec )
+
+  end subroutine add_conditions_to_goveqns_for_two_trees
 
   !------------------------------------------------------------------------
   subroutine allocate_auxvars()
@@ -450,7 +864,8 @@ contains
   end subroutine allocate_auxvars
 
   !------------------------------------------------------------------------
-  subroutine set_material_properties()
+  subroutine set_material_properties_for_single_tree(local_nz, local_porosity, &
+       local_phi88, local_phi50, local_kmax, local_c1, local_c2, local_c3, local_phis50)
     !
     ! !DESCRIPTION:
     !
@@ -468,12 +883,16 @@ contains
     !
     implicit none
     !
-    PetscReal , pointer   :: vsfm_watsat(:,:)
-    PetscReal , pointer   :: vsfm_hksat(:,:)
-    PetscReal , pointer   :: vsfm_bsw(:,:)
-    PetscReal , pointer   :: vsfm_sucsat(:,:)
-    PetscReal , pointer   :: vsfm_eff_porosity(:,:)
-    PetscReal , pointer   :: vsfm_residual_sat(:,:)
+    PetscInt  :: local_nz
+    PetscReal :: local_porosity
+    PetscReal :: local_phi88
+    PetscReal :: local_phi50
+    PetscReal :: local_kmax
+    PetscReal :: local_c1
+    PetscReal :: local_c2
+    PetscReal :: local_c3
+    PetscReal :: local_phis50
+    !
     PetscReal , pointer   :: por(:)
     PetscReal , pointer   :: alpha(:)
     PetscReal , pointer   :: lambda(:)
@@ -488,42 +907,42 @@ contains
     PetscInt              :: ieqn
     !-----------------------------------------------------------------------
 
-    allocate (por            (nz))
-    allocate (alpha          (nz))
-    allocate (lambda         (nz))
-    allocate (sat_res        (nz))
-    allocate (satfunc_type   (nz))
-    allocate (perm           (nz))
-    allocate (relperm_type   (nz))
-    allocate (weibull_d      (nz))
-    allocate (weibull_c      (nz))
-    allocate(ss_auxvar_value (nz))
+    allocate (por            (local_nz))
+    allocate (alpha          (local_nz))
+    allocate (lambda         (local_nz))
+    allocate (sat_res        (local_nz))
+    allocate (satfunc_type   (local_nz))
+    allocate (perm           (local_nz))
+    allocate (relperm_type   (local_nz))
+    allocate (weibull_d      (local_nz))
+    allocate (weibull_c      (local_nz))
+    allocate(ss_auxvar_value (local_nz))
 
-    por          (1 : nz ) = porosity
+    por          (1 : local_nz ) = local_porosity
     call VSFMMPPSetSoilPorosity(vsfm_mpp, 1, por)
 
-    satfunc_type (1 : nz ) = SAT_FUNC_FETCH2
-    alpha        (1 : nz ) = phi88
-    lambda       (1 : nz ) = phi50
-    sat_res      (1 : nz ) = 0.d0
+    satfunc_type (1 : local_nz ) = SAT_FUNC_FETCH2
+    alpha        (1 : local_nz ) = local_phi88
+    lambda       (1 : local_nz ) = local_phi50
+    sat_res      (1 : local_nz ) = 0.d0
     call VSFMMPPSetSaturationFunction(vsfm_mpp, 1, satfunc_type, &
          alpha, lambda, sat_res)
 
 
-    perm         (1 : nz ) = kmax  * vis / rho
+    perm         (1 : local_nz ) = local_kmax  * vis / rho * 1.125d0
     call VSFMMPPSetSoilPermeability(vsfm_mpp, 1, perm, perm, perm)
 
     relperm_type (:) = RELPERM_FUNC_WEIBULL
-    weibull_d    (:) = c1
-    weibull_c    (:) = c2
+    weibull_d    (:) = local_c1
+    weibull_c    (:) = local_c2
     
     call VSFMMPPSetRelativePermeability(vsfm_mpp, 1, relperm_type, weibull_d, weibull_c)
 
-    ss_auxvar_value(:) = c3
+    ss_auxvar_value(:) = local_c3
     call VSFMMPPSetSourceSinkAuxVarRealValue(vsfm_mpp, 1, &
          VAR_POT_MASS_SINK_EXPONENT, ss_auxvar_value)
 
-    ss_auxvar_value(:) = phis50
+    ss_auxvar_value(:) = local_phis50
     call VSFMMPPSetSourceSinkAuxVarRealValue(vsfm_mpp, 1, &
          VAR_POT_MASS_SINK_PRESSURE, ss_auxvar_value)
 
@@ -538,10 +957,155 @@ contains
     deallocate(weibull_d    )
     deallocate(ss_auxvar_value)
 
-  end subroutine set_material_properties
+  end subroutine set_material_properties_for_single_tree
 
   !------------------------------------------------------------------------
-  subroutine set_initial_conditions()
+  subroutine set_material_properties_for_two_trees()
+    !
+    ! !DESCRIPTION:
+    !
+    use MultiPhysicsProbVSFM      , only : vsfm_mpp
+    use MultiPhysicsProbVSFM      , only : VSFMMPPSetSourceSinkAuxVarRealValue
+    use MultiPhysicsProbVSFM      , only : VSFMMPPSetSoilPorosity
+    use MultiPhysicsProbVSFM      , only : VSFMMPPSetSaturationFunction
+    use MultiPhysicsProbVSFM      , only : VSFMMPPSetSoilPermeability
+    use MultiPhysicsProbVSFM      , only : VSFMMPPSetRelativePermeability
+    use MultiPhysicsProbConstants , only : VAR_POT_MASS_SINK_PRESSURE
+    use MultiPhysicsProbConstants , only : VAR_POT_MASS_SINK_EXPONENT
+    use EOSWaterMod               , only : DENSITY_TGDPB01
+    use SaturationFunction        , only : SAT_FUNC_FETCH2
+    use SaturationFunction        , only : RELPERM_FUNC_WEIBULL
+    !
+    implicit none
+    !
+    PetscInt              :: nz
+    PetscReal , pointer   :: por(:)
+    PetscReal , pointer   :: alpha(:)
+    PetscReal , pointer   :: lambda(:)
+    PetscReal , pointer   :: sat_res(:)
+    PetscReal , pointer   :: perm(:)
+    PetscInt  , pointer   :: vsfm_filter(:)
+    PetscInt  , pointer   :: satfunc_type(:)
+    PetscInt  , pointer   :: relperm_type(:)
+    PetscReal , pointer   :: ss_auxvar_value(:)
+    PetscReal , pointer   :: weibull_d(:)
+    PetscReal , pointer   :: weibull_c(:)
+    PetscInt              :: ieqn
+    !-----------------------------------------------------------------------
+
+    nz = oak_nz + pine_nz
+    
+    allocate (por            (nz))
+    allocate (alpha          (nz))
+    allocate (lambda         (nz))
+    allocate (sat_res        (nz))
+    allocate (satfunc_type   (nz))
+    allocate (perm           (nz))
+    allocate (relperm_type   (nz))
+    allocate (weibull_d      (nz))
+    allocate (weibull_c      (nz))
+    allocate(ss_auxvar_value (nz))
+
+    por(1:oak_nz ) = porosity; por(oak_nz+1:oak_nz+pine_nz ) = porosity
+
+    call VSFMMPPSetSoilPorosity(vsfm_mpp, 1, por)
+
+    satfunc_type (1:oak_nz ) = SAT_FUNC_FETCH2 ; satfunc_type (oak_nz+1:oak_nz+pine_nz ) = SAT_FUNC_FETCH2
+    alpha        (1:oak_nz ) = oak_phi88       ; alpha        (oak_nz+1:oak_nz+pine_nz ) = pine_phi88
+    lambda       (1:oak_nz ) = oak_phi50       ; lambda       (oak_nz+1:oak_nz+pine_nz ) = pine_phi50
+    sat_res      (1:oak_nz ) = 0.d0            ; sat_res      (oak_nz+1:oak_nz+pine_nz ) = 0.d0;
+    call VSFMMPPSetSaturationFunction(vsfm_mpp, 1, satfunc_type, &
+         alpha, lambda, sat_res)
+
+
+    perm (1:oak_nz ) = oak_kmax  * vis / rho; perm (oak_nz+1:oak_nz+pine_nz ) = pine_kmax  * vis / rho
+    call VSFMMPPSetSoilPermeability(vsfm_mpp, 1, perm, perm, perm)
+
+    relperm_type (1:oak_nz) = RELPERM_FUNC_WEIBULL ; relperm_type (oak_nz+1:oak_nz+pine_nz) = RELPERM_FUNC_WEIBULL
+    weibull_d    (1:oak_nz) = oak_c1               ; weibull_d    (oak_nz+1:oak_nz+pine_nz) = pine_c1
+    weibull_c    (1:oak_nz) = oak_c2               ; weibull_c    (oak_nz+1:oak_nz+pine_nz) = pine_c2
+    
+    call VSFMMPPSetRelativePermeability(vsfm_mpp, 1, relperm_type, weibull_d, weibull_c)
+
+    ss_auxvar_value(1:oak_nz) = oak_c3; ss_auxvar_value(oak_nz+1:oak_nz+pine_nz) = pine_c3
+    call VSFMMPPSetSourceSinkAuxVarRealValue(vsfm_mpp, 1, &
+         VAR_POT_MASS_SINK_EXPONENT, ss_auxvar_value)
+
+    ss_auxvar_value(1:oak_nz) = oak_phis50; ss_auxvar_value(oak_nz+1:oak_nz+pine_nz) = pine_phis50
+    call VSFMMPPSetSourceSinkAuxVarRealValue(vsfm_mpp, 1, &
+         VAR_POT_MASS_SINK_PRESSURE, ss_auxvar_value)
+
+    deallocate(por          )
+    deallocate(sat_res      )
+    deallocate(lambda       )
+    deallocate(alpha        )
+    deallocate(perm         )
+    deallocate(satfunc_type )
+    deallocate(relperm_type )
+    deallocate(weibull_c    )
+    deallocate(weibull_d    )
+    deallocate(ss_auxvar_value)
+
+  end subroutine set_material_properties_for_two_trees
+
+  !------------------------------------------------------------------------
+  subroutine set_initial_conditions_for_single_tree(nz)
+    !
+    ! !DESCRIPTION:
+    !
+    use MultiPhysicsProbVSFM      , only : vsfm_mpp
+    use petscsys
+    use petscvec
+    use petscmat
+    use petscts
+    use petscsnes
+    use petscdm
+    use petscdmda
+    !
+    implicit none
+    !
+    PetscInt           :: nz
+    !
+    PetscReal          :: theta
+    PetscReal          :: phi_root_mean_times_beta_s
+    PetscInt           :: ii
+    PetscReal, pointer :: press_ic(:)
+    PetscErrorCode     :: ierr
+
+    Vec                :: p_init
+    PetscViewer        :: viewer
+    PetscReal, pointer :: p_init_ptr(:)
+
+    phi_root_mean_times_beta_s = 5.831916333333334e+03
+
+    if (ic_file_specified) then
+       call PetscViewerBinaryOpen(PETSC_COMM_WORLD, ic_filename, FILE_MODE_READ, &
+            viewer, ierr); CHKERRQ(ierr)
+       ! Load the data
+       call VecCreate(PETSC_COMM_WORLD, p_init, ierr); CHKERRQ(ierr)
+       call VecLoad(p_init, viewer, ierr); CHKERRQ(ierr)
+       call PetscViewerDestroy(viewer, ierr); CHKERRQ(ierr)
+
+       call VecCopy(p_init, vsfm_mpp%soe%solver%soln, ierr); CHKERRQ(ierr)
+       call VecGetArrayF90(p_init, p_init_ptr, ierr); CHKERRQ(ierr)
+       call vsfm_mpp%Restart(p_init_ptr)
+       call VecRestoreArrayF90(p_init, p_init_ptr, ierr); CHKERRQ(ierr)
+    else
+       call VecGetArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+       do ii = 1, nz
+          press_ic(ii) = -phi_root_mean_times_beta_s - rho * grav * (0.17d0 + (nz - ii)*dz) + 101325.d0
+       enddo
+       call vsfm_mpp%Restart(press_ic)
+       call VecRestoreArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+    end if
+
+    call VecCopy(vsfm_mpp%soe%solver%soln, vsfm_mpp%soe%solver%soln_prev, ierr); CHKERRQ(ierr)
+    call VecCopy(vsfm_mpp%soe%solver%soln, vsfm_mpp%soe%solver%soln_prev_clm, ierr); CHKERRQ(ierr)
+    
+  end subroutine set_initial_conditions_for_single_tree
+
+  !------------------------------------------------------------------------
+  subroutine set_initial_conditions_for_two_trees()
     !
     ! !DESCRIPTION:
     !
@@ -562,21 +1126,70 @@ contains
     PetscReal, pointer :: press_ic(:)
     PetscErrorCode     :: ierr
 
+    Vec                :: p_init
+    PetscViewer        :: viewer
+    PetscReal, pointer :: p_init_ptr(:)
+
     phi_root_mean_times_beta_s = 5.831916333333334e+03
     
-    call VecGetArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
-    do ii = 1, nz
-       press_ic(nz-ii+1) = -phi_root_mean_times_beta_s - rho * grav * (0.17d0 + (ii-1)*dz) + 101325.d0
-    enddo
-    call VecRestoreArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+    if (ic_file_specified) then
+       call PetscViewerBinaryOpen(PETSC_COMM_WORLD, ic_filename, FILE_MODE_READ, &
+            viewer, ierr); CHKERRQ(ierr)
+       ! Load the data
+       call VecCreate(PETSC_COMM_WORLD, p_init, ierr); CHKERRQ(ierr)
+       call VecLoad(p_init, viewer, ierr); CHKERRQ(ierr)
+       call PetscViewerDestroy(viewer, ierr); CHKERRQ(ierr)
+
+       call VecCopy(p_init, vsfm_mpp%soe%solver%soln, ierr); CHKERRQ(ierr)
+       call VecGetArrayF90(p_init, p_init_ptr, ierr); CHKERRQ(ierr)
+       call vsfm_mpp%Restart(p_init_ptr)
+       call VecRestoreArrayF90(p_init, p_init_ptr, ierr); CHKERRQ(ierr)
+    else
+       call VecGetArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+       do ii = 1, oak_nz
+          press_ic(ii         ) = -phi_root_mean_times_beta_s - rho * grav * (0.17d0 + (oak_nz - ii)*dz) + 101325.d0
+       enddo
+
+       do ii = 1, pine_nz
+          press_ic(ii + oak_nz) = -phi_root_mean_times_beta_s - rho * grav * (0.17d0 + (pine_nz - ii)*dz) + 101325.d0
+       enddo
+       call vsfm_mpp%Restart(press_ic)
+       call VecRestoreArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+    end if
 
     call VecCopy(vsfm_mpp%soe%solver%soln, vsfm_mpp%soe%solver%soln_prev, ierr); CHKERRQ(ierr)
     call VecCopy(vsfm_mpp%soe%solver%soln, vsfm_mpp%soe%solver%soln_prev_clm, ierr); CHKERRQ(ierr)
+
+#if 0
+    call PetscViewerBinaryOpen(PETSC_COMM_WORLD, 'initial_pressure.bin', FILE_MODE_READ, viewer, ierr); CHKERRQ(ierr)
+    call VecCreate(PETSC_COMM_WORLD, p_init, ierr); CHKERRQ(ierr)
+    call VecLoad(p_init, viewer, ierr); CHKERRQ(ierr)
+    call PetscViewerDestroy(viewer, ierr); CHKERRQ(ierr)
+
+    call VecGetArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+    call VecGetArrayF90(p_init, p_init_ptr, ierr); CHKERRQ(ierr)
+
+    do ii = 1, oak_nz
+       press_ic(ii         ) = -phi_root_mean_times_beta_s - rho * grav * (0.17d0 + (oak_nz - ii)*dz) + 101325.d0
+    enddo
+
+    do ii = 1, pine_nz
+       press_ic(ii + oak_nz) = -phi_root_mean_times_beta_s - rho * grav * (0.17d0 + (pine_nz - ii)*dz) + 101325.d0
+    enddo
+
+    call vsfm_mpp%Restart(press_ic)
+    call VecRestoreArrayF90(vsfm_mpp%soe%solver%soln, press_ic, ierr); CHKERRQ(ierr)
+
+    call VecRestoreArrayF90(p_init, p_init_ptr, ierr); CHKERRQ(ierr)
+
+    call VecCopy(vsfm_mpp%soe%solver%soln, vsfm_mpp%soe%solver%soln_prev, ierr); CHKERRQ(ierr)
+    call VecCopy(vsfm_mpp%soe%solver%soln, vsfm_mpp%soe%solver%soln_prev_clm, ierr); CHKERRQ(ierr)
+#endif
     
-  end subroutine set_initial_conditions
+  end subroutine set_initial_conditions_for_two_trees
 
   !------------------------------------------------------------------------
-  subroutine set_bondary_conditions(nstep, ET, SoilBC)
+  subroutine set_bondary_conditions_for_single_tree(nz, nstep, ET, SoilBC)
     !
     ! !DESCRIPTION:
     !
@@ -588,6 +1201,7 @@ contains
     !
     implicit none
     !
+    PetscInt           :: nz
     PetscInt           :: nstep
     !
     PetscReal, pointer :: ss_value(:)
@@ -605,7 +1219,7 @@ contains
 
     call VecGetArrayF90(ET, et_p, ierr)
     do kk = 1, nz
-       ss_value(nz-kk+1) = -et_p(nz*(nstep-1) + kk) * dz
+       ss_value(kk) = -et_p(nz*(nstep-1) + kk) * dz
     end do
     call VecRestoreArrayF90(ET, et_p, ierr)
 
@@ -624,10 +1238,65 @@ contains
     deallocate(bc_value)
     call VecRestoreArrayF90(SoilBC, soilbc_p, ierr)
 
-  end subroutine set_bondary_conditions
+  end subroutine set_bondary_conditions_for_single_tree
 
   !------------------------------------------------------------------------
-  subroutine diagnose_actual_sink(nstep, act_et_p)
+  subroutine set_bondary_conditions_for_two_trees(nz, nstep, ET, SoilBC)
+    !
+    ! !DESCRIPTION:
+    !
+    use MultiPhysicsProbVSFM      , only : vsfm_mpp
+    use MultiPhysicsProbConstants , only : AUXVAR_BC, VAR_BC_SS_CONDITION
+    use MultiPhysicsProbConstants , only : AUXVAR_SS
+    use petscsys
+    use petscvec
+    !
+    implicit none
+    !
+    PetscInt           :: nz
+    PetscInt           :: nstep
+    !
+    PetscReal, pointer :: ss_value(:)
+    PetscReal, pointer :: bc_value(:)
+    PetscViewer        :: viewer
+    Vec                :: ET
+    Vec                :: SoilBC
+    PetscReal, pointer :: et_p(:)
+    PetscReal, pointer :: soilbc_p(:)
+    PetscErrorCode     :: ierr
+    PetscInt           :: soe_auxvar_id
+    PetscInt           :: kk
+
+    allocate(ss_value(nz))
+
+    ! Set source sink
+    call VecGetArrayF90(ET, et_p, ierr)
+    
+    do kk = 1, nz
+       ss_value(kk) = -et_p(nz*(nstep-1) + kk)*dz
+    end do
+    call VecRestoreArrayF90(ET, et_p, ierr)
+
+    soe_auxvar_id = 1
+    call vsfm_mpp%soe%SetDataFromCLM(AUXVAR_SS,  &
+         VAR_BC_SS_CONDITION, soe_auxvar_id, ss_value)
+
+    deallocate(ss_value)
+
+    ! Set BC
+    call VecGetArrayF90(SoilBC, soilbc_p, ierr)
+    allocate(bc_value(2))
+    bc_value(1:2) = soilbc_p(nstep)
+        soe_auxvar_id = 1
+    call vsfm_mpp%soe%SetDataFromCLM(AUXVAR_BC,  &
+         VAR_BC_SS_CONDITION, soe_auxvar_id, bc_value)
+    deallocate(bc_value)
+    call VecRestoreArrayF90(SoilBC, soilbc_p, ierr)
+
+  end subroutine set_bondary_conditions_for_two_trees
+
+  !------------------------------------------------------------------------
+  subroutine diagnose_actual_sink_for_single_tree(nz, nstep, act_et_p)
     !
     ! !DESCRIPTION:
     !
@@ -641,11 +1310,12 @@ contains
     !
     implicit none
     !
+    PetscInt           :: nz
     PetscInt           :: nstep
+    PetscReal, pointer :: act_et_p(:)
     !
     PetscReal, pointer :: ss_value(:)
     PetscReal, pointer :: press(:)
-    PetscReal, pointer :: act_et_p(:)
     PetscInt           :: kk
 
     allocate(ss_value(nz))
@@ -653,13 +1323,15 @@ contains
 
     call vsfm_mpp%soe%GetDataForCLM(AUXVAR_SS, VAR_MASS_FLUX, 1, ss_value)
     call vsfm_mpp%soe%GetDataForCLM(AUXVAR_INTERNAL,VAR_PRESSURE, -1, press)
+    !write(*,*)'sink:'
     do kk = 1, nz
        act_et_p((nstep-1)*nz + kk) = ss_value(kk)
+       !write(*,*)kk,ss_value(kk)
     end do
     
     deallocate(ss_value)
     deallocate(press)
 
-  end subroutine diagnose_actual_sink
+  end subroutine diagnose_actual_sink_for_single_tree
 
 end module vsfm_spac_fetch2_problem

--- a/src/driver/standalone/vsfm/vsfm_spac_fetch2_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_spac_fetch2_problem.F90
@@ -356,7 +356,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_DOWNREG_MASS_RATE_FETCH2
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     use petscsys
     !

--- a/src/driver/standalone/vsfm/vsfm_spac_on_hillslope.F90
+++ b/src/driver/standalone/vsfm/vsfm_spac_on_hillslope.F90
@@ -433,7 +433,6 @@ contains
     use MultiPhysicsProbConstants , only : CONN_SET_INTERNAL
     use MultiPhysicsProbVSFM      , only : mpp_vsfm_type
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     use petscsys
     !
@@ -443,7 +442,7 @@ contains
     class (mpp_vsfm_type)            :: vsfm_mpp
     PetscBool                        :: reverse_up2dn
     !
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
     PetscInt                  , pointer :: id(:)
     PetscInt                            :: iconn
     PetscInt                            :: eqn_id
@@ -508,8 +507,6 @@ contains
          num_other_goveqs   = 1             , &
          id_of_other_goveqs = ieqn_other    , &
          conn_set           = conn_set)
-
-    call ConnectionSetDestroy(conn_set)
 
     deallocate(id)
     deallocate(ieqn_other)
@@ -2121,7 +2118,6 @@ subroutine add_conditions_to_goveqns()
   use MultiPhysicsProbConstants , only : COND_DOWNREG_MASS_RATE_FETCH2
   use MultiPhysicsProbConstants , only : CONN_VERTICAL
   use ConnectionSetType         , only : connection_set_type
-  use ConnectionSetType         , only : ConnectionSetDestroy
   use MeshType                  , only : MeshCreateConnectionSet
   use petscsys
   use problem_parameters
@@ -2152,7 +2148,6 @@ subroutine add_coupling_conditions_to_goveqns()
   use MultiPhysicsProbConstants , only : COND_DOWNREG_MASS_RATE_FETCH2
   use MultiPhysicsProbConstants , only : CONN_VERTICAL
   use ConnectionSetType         , only : connection_set_type
-  use ConnectionSetType         , only : ConnectionSetDestroy
   use MeshType                  , only : MeshCreateConnectionSet
   use problem_parameters
   use petscsys

--- a/src/driver/standalone/vsfm/vsfm_spac_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_spac_problem.F90
@@ -326,7 +326,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_DOWNREG_MASS_RATE_CAMPBELL
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     !
     ! !ARGUMENTS
@@ -349,7 +348,7 @@ contains
     PetscReal                 , pointer :: area(:)
     PetscInt                  , pointer :: itype(:)
     PetscReal                 , pointer :: unit_vec(:,:)
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
 
 
     nconn         = 28
@@ -390,9 +389,6 @@ contains
     call vsfm_mpp%soe%AddConditionInGovEqn(ieqn, COND_SS,   &
          'Potential Mass_Flux', 'kg/s', COND_DOWNREG_MASS_RATE_CAMPBELL, &
          SOIL_BOTTOM_CELLS)
-
-
-    call ConnectionSetDestroy(conn_set)
 
 
     deallocate(id_up          )

--- a/src/driver/standalone/vsfm/vsfm_sy1991_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_sy1991_problem.F90
@@ -267,134 +267,37 @@ contains
   subroutine add_meshes()
     !
     use MultiPhysicsProbVSFM      , only : vsfm_mpp
-    use MultiPhysicsProbConstants , only : MESH_ALONG_GRAVITY
-    use MultiPhysicsProbConstants , only : MESH_AGAINST_GRAVITY
-    use MultiPhysicsProbConstants , only : MESH_CLM_SOIL_COL
-    use MultiPhysicsProbConstants , only : VAR_XC
-    use MultiPhysicsProbConstants , only : VAR_YC
-    use MultiPhysicsProbConstants , only : VAR_ZC
-    use MultiPhysicsProbConstants , only : VAR_DX
-    use MultiPhysicsProbConstants , only : VAR_DY
-    use MultiPhysicsProbConstants , only : VAR_DZ
-    use MultiPhysicsProbConstants , only : VAR_AREA
-    use MultiPhysicsProbConstants , only : CONN_SET_INTERNAL
-    use MultiPhysicsProbConstants , only : CONN_SET_LATERAL
-    use MultiPhysicsProbConstants , only : CONN_VERTICAL
+    use MultiPhysicsProbConstants , only : CONN_IN_Z_DIR
     use mpp_varpar                , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
+    use MeshType                  , only : mesh_type, MeshCreate
     !
     implicit none
     !
-#include <petsc/finclude/petsc.h>
-    !
-    PetscReal :: dx, dy, dz
-    PetscInt :: imesh, kk
-    PetscInt :: nlev
-    PetscInt :: iconn, vert_nconn
-    PetscReal, pointer :: soil_xc(:)           ! x-position of grid cell [m]
-    PetscReal, pointer :: soil_yc(:)           ! y-position of grid cell [m]
-    PetscReal, pointer :: soil_zc(:)           ! z-position of grid cell [m]
-    PetscReal, pointer :: soil_dx(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_dy(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_dz(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_area(:)         ! area of grid cell [m^2]
-    PetscInt , pointer :: soil_filter(:)       ! 
-
-    PetscInt, pointer  :: vert_conn_id_up(:)   !
-    PetscInt, pointer  :: vert_conn_id_dn(:)   !
-    PetscReal, pointer :: vert_conn_dist_up(:) !
-    PetscReal, pointer :: vert_conn_dist_dn(:) !
-    PetscReal, pointer :: vert_conn_area(:)    !
-    PetscInt , pointer :: vert_conn_type(:)    !
-
-    PetscErrorCode :: ierr
+    class(mesh_type), pointer :: mesh
+    PetscInt                  :: imesh
+    PetscInt                  :: nlev
 
     call mpp_varpar_set_nlevsoi(nz)
     call mpp_varpar_set_nlevgrnd(nz)
 
-    dx = x_column/nx
-    dy = y_column/ny
-    dz = z_column/nz
-
     imesh        = 1
     nlev         = nz
-    ncells_local = nx*ny*nz
-    ncells_ghost = 0
 
-    allocate(soil_xc(nz))
-    allocate(soil_yc(nz))
-    allocate(soil_zc(nz))
-    allocate(soil_dx(nz))
-    allocate(soil_dy(nz))
-    allocate(soil_dz(nz))
-    allocate(soil_area(nz))
-    allocate(soil_filter(nz))
-
-    soil_filter (:) = 1
-    soil_area   (:) = dx*dy
-    soil_dx     (:) = dx
-    soil_dy     (:) = dy
-    soil_dz     (:) = dz
-    soil_xc     (:) = dx/2.d0
-    soil_yc     (:) = dy/2.d0
-
-    do kk = 1,nz
-       soil_zc(kk) = dz/2.d0 + dz * (kk - 1)
-    enddo
-    
     !
     ! Set up the meshes
     !    
     call vsfm_mpp%SetNumMeshes(1)
 
-    call vsfm_mpp%MeshSetName        (imesh, 'Soil mesh')
-    call vsfm_mpp%MeshSetOrientation (imesh, MESH_AGAINST_GRAVITY)
-    call vsfm_mpp%MeshSetID          (imesh, MESH_CLM_SOIL_COL)
-    call vsfm_mpp%MeshSetDimensions  (imesh, ncells_local, ncells_ghost, nlev)
+    allocate(mesh)
 
-    call vsfm_mpp%MeshSetGridCellFilter      (imesh, soil_filter)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_XC   , soil_xc)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_YC   , soil_yc)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_ZC   , soil_zc)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DX   , soil_dx)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DY   , soil_dy)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DZ   , soil_dz)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_AREA , soil_area)
-    call vsfm_mpp%MeshComputeVolume          (imesh)
+    call MeshCreate(mesh, 'Soil mesh', x_column, y_column, z_column, &
+         nx, ny, nz, CONN_IN_Z_DIR)
 
-    allocate (vert_conn_id_up   (nz-1))
-    allocate (vert_conn_id_dn   (nz-1))
-    allocate (vert_conn_dist_up (nz-1))
-    allocate (vert_conn_dist_dn (nz-1))
-    allocate (vert_conn_area    (nz-1))
-    allocate (vert_conn_type    (nz-1))
+    call vsfm_mpp%AddMesh(imesh, mesh)
 
-    iconn = 0
-    do kk = 1, nz-1
+    call mesh%Clean()
 
-       iconn = iconn + 1
-       vert_conn_id_up(iconn)   = kk
-       vert_conn_id_dn(iconn)   = vert_conn_id_up(iconn) + 1
-       vert_conn_dist_up(iconn) = 0.5d0*dz
-       vert_conn_dist_dn(iconn) = 0.5d0*dz
-       vert_conn_area(iconn)    = soil_area(kk)
-       vert_conn_type(iconn)    = CONN_VERTICAL
-
-    end do
-    vert_nconn = iconn
-
-    call vsfm_mpp%MeshSetConnectionSet(imesh, CONN_SET_INTERNAL, &
-         vert_nconn,  vert_conn_id_up, vert_conn_id_dn,          &
-         vert_conn_dist_up, vert_conn_dist_dn,  vert_conn_area,  &
-         vert_conn_type)
-
-    deallocate(soil_xc)
-    deallocate(soil_yc)
-    deallocate(soil_zc)
-    deallocate(soil_dx)
-    deallocate(soil_dy)
-    deallocate(soil_dz)
-    deallocate(soil_area)
-    deallocate(soil_filter)  
+    deallocate(mesh)
 
   end subroutine add_meshes
 

--- a/src/driver/standalone/vsfm/vsfm_vchannel_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_vchannel_problem.F90
@@ -847,7 +847,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_SEEPAGE_BC
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     !
     ! !ARGUMENTS
@@ -864,7 +863,7 @@ contains
     PetscReal                 , pointer :: conn_area(:)    !
     PetscInt                  , pointer :: conn_type(:)    !
     PetscReal                 , pointer :: conn_unitvec(:,:)
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
 
     if (.not. with_seepage_bc) return
 
@@ -904,8 +903,6 @@ contains
     call vsfm_mpp%soe%AddConditionInGovEqn(ieqn, COND_BC,   &
          'Constant head condition at top', 'Pa', COND_SEEPAGE_BC, &
          SOIL_TOP_CELLS, conn_set)
-
-    call ConnectionSetDestroy(conn_set)
 
     deallocate (conn_id_up   )
     deallocate (conn_id_dn   )

--- a/src/driver/standalone/vsfm/vsfm_vchannel_problem_operator_split.F90
+++ b/src/driver/standalone/vsfm/vsfm_vchannel_problem_operator_split.F90
@@ -909,7 +909,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_SEEPAGE_BC
     use MultiPhysicsProbConstants , only : CONN_VERTICAL
     use ConnectionSetType         , only : connection_set_type
-    use ConnectionSetType         , only : ConnectionSetDestroy
     use MeshType                  , only : MeshCreateConnectionSet
     !
     ! !ARGUMENTS
@@ -926,7 +925,7 @@ contains
     PetscReal                 , pointer :: conn_area(:)    !
     PetscInt                  , pointer :: conn_type(:)    !
     PetscReal                 , pointer :: conn_unitvec(:,:)
-    type(connection_set_type) , pointer :: conn_set
+    class(connection_set_type) , pointer :: conn_set
 
     if (.not. with_seepage_bc) return
 
@@ -966,8 +965,6 @@ contains
     call vsfm_mpp_vertical%soe%AddConditionInGovEqn(ieqn, COND_BC,   &
          'Constant head condition at top', 'Pa', COND_SEEPAGE_BC, &
          SOIL_TOP_CELLS, conn_set)
-
-    call ConnectionSetDestroy(conn_set)
 
     !icond = 1
     !call vsfm_mpp_lateral%GovEqnUpdateConditionConnSet(ieqn, icond, COND_BC, &

--- a/src/driver/standalone/vsfm/vsfm_wt_dynamics_problem.F90
+++ b/src/driver/standalone/vsfm/vsfm_wt_dynamics_problem.F90
@@ -239,134 +239,43 @@ contains
   subroutine add_meshes()
     !
     use MultiPhysicsProbVSFM      , only : vsfm_mpp
-    use MultiPhysicsProbConstants , only : MESH_ALONG_GRAVITY
-    use MultiPhysicsProbConstants , only : MESH_AGAINST_GRAVITY
-    use MultiPhysicsProbConstants , only : MESH_CLM_SOIL_COL
-    use MultiPhysicsProbConstants , only : VAR_XC
-    use MultiPhysicsProbConstants , only : VAR_YC
-    use MultiPhysicsProbConstants , only : VAR_ZC
-    use MultiPhysicsProbConstants , only : VAR_DX
-    use MultiPhysicsProbConstants , only : VAR_DY
-    use MultiPhysicsProbConstants , only : VAR_DZ
-    use MultiPhysicsProbConstants , only : VAR_AREA
-    use MultiPhysicsProbConstants , only : CONN_SET_INTERNAL
-    use MultiPhysicsProbConstants , only : CONN_SET_LATERAL
-    use MultiPhysicsProbConstants , only : CONN_VERTICAL
+    use MultiPhysicsProbConstants , only : CONN_IN_Z_DIR
     use mpp_varpar                , only : mpp_varpar_set_nlevsoi, mpp_varpar_set_nlevgrnd
+    use MeshType                  , only : mesh_type, MeshCreate
     !
     implicit none
     !
-#include <petsc/finclude/petsc.h>
-    !
-    PetscReal :: dx, dy, dz
-    PetscInt :: imesh, kk
-    PetscInt :: nlev
-    PetscInt :: iconn, vert_nconn
-    PetscReal, pointer :: soil_xc(:)           ! x-position of grid cell [m]
-    PetscReal, pointer :: soil_yc(:)           ! y-position of grid cell [m]
-    PetscReal, pointer :: soil_zc(:)           ! z-position of grid cell [m]
-    PetscReal, pointer :: soil_dx(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_dy(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_dz(:)           ! layer thickness of grid cell [m]
-    PetscReal, pointer :: soil_area(:)         ! area of grid cell [m^2]
-    PetscInt , pointer :: soil_filter(:)       ! 
-
-    PetscInt, pointer  :: vert_conn_id_up(:)   !
-    PetscInt, pointer  :: vert_conn_id_dn(:)   !
-    PetscReal, pointer :: vert_conn_dist_up(:) !
-    PetscReal, pointer :: vert_conn_dist_dn(:) !
-    PetscReal, pointer :: vert_conn_area(:)    !
-    PetscInt , pointer :: vert_conn_type(:)    !
-
-    PetscErrorCode :: ierr
+    class(mesh_type), pointer :: mesh
+    PetscInt                  :: imesh
+    PetscInt                  :: nlev
 
     call mpp_varpar_set_nlevsoi(nz)
     call mpp_varpar_set_nlevgrnd(nz)
 
-    dx = x_column/nx
-    dy = y_column/ny
-    dz = z_column/nz
+    imesh        = 1
+    nlev         = nz
+
+    call mpp_varpar_set_nlevsoi(nz)
+    call mpp_varpar_set_nlevgrnd(nz)
 
     imesh        = 1
     nlev         = nz
-    ncells_local = nx*ny*nz
-    ncells_ghost = 0
-
-    allocate(soil_xc(nz))
-    allocate(soil_yc(nz))
-    allocate(soil_zc(nz))
-    allocate(soil_dx(nz))
-    allocate(soil_dy(nz))
-    allocate(soil_dz(nz))
-    allocate(soil_area(nz))
-    allocate(soil_filter(nz))
-
-    soil_filter (:) = 1
-    soil_area   (:) = dx*dy
-    soil_dx     (:) = dx
-    soil_dy     (:) = dy
-    soil_dz     (:) = dz
-    soil_xc     (:) = dx/2.d0
-    soil_yc     (:) = dy/2.d0
-
-    do kk = 1,nz
-       soil_zc(kk) = dz/2.d0 + dz * (kk - 1)
-    enddo
 
     !
     ! Set up the meshes
     !    
     call vsfm_mpp%SetNumMeshes(1)
 
-    call vsfm_mpp%MeshSetName        (imesh, 'Soil mesh')
-    call vsfm_mpp%MeshSetOrientation (imesh, MESH_AGAINST_GRAVITY)
-    call vsfm_mpp%MeshSetID          (imesh, MESH_CLM_SOIL_COL)
-    call vsfm_mpp%MeshSetDimensions  (imesh, ncells_local, ncells_ghost, nlev)
+    allocate(mesh)
 
-    call vsfm_mpp%MeshSetGridCellFilter      (imesh, soil_filter)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_XC   , soil_xc)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_YC   , soil_yc)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_ZC   , soil_zc)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DX   , soil_dx)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DY   , soil_dy)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_DZ   , soil_dz)
-    call vsfm_mpp%MeshSetGeometricAttributes (imesh, VAR_AREA , soil_area)
-    call vsfm_mpp%MeshComputeVolume          (imesh)
+    call MeshCreate(mesh, 'Soil mesh', x_column, y_column, z_column, &
+         nx, ny, nz, CONN_IN_Z_DIR)
 
-    allocate (vert_conn_id_up   (nz-1))
-    allocate (vert_conn_id_dn   (nz-1))
-    allocate (vert_conn_dist_up (nz-1))
-    allocate (vert_conn_dist_dn (nz-1))
-    allocate (vert_conn_area    (nz-1))
-    allocate (vert_conn_type    (nz-1))
+    call vsfm_mpp%AddMesh(imesh, mesh)
 
-    iconn = 0
-    do kk = 1, nz-1
+    call mesh%Clean()
 
-       iconn = iconn + 1
-       vert_conn_id_up(iconn)   = kk
-       vert_conn_id_dn(iconn)   = vert_conn_id_up(iconn) + 1
-       vert_conn_dist_up(iconn) = 0.5d0*dz
-       vert_conn_dist_dn(iconn) = 0.5d0*dz
-       vert_conn_area(iconn)    = soil_area(kk)
-       vert_conn_type(iconn)    = CONN_VERTICAL
-
-    end do
-    vert_nconn = iconn
-
-    call vsfm_mpp%MeshSetConnectionSet(imesh, CONN_SET_INTERNAL, &
-         vert_nconn,  vert_conn_id_up, vert_conn_id_dn,          &
-         vert_conn_dist_up, vert_conn_dist_dn,  vert_conn_area,  &
-         vert_conn_type)
-
-    deallocate(soil_xc)
-    deallocate(soil_yc)
-    deallocate(soil_zc)
-    deallocate(soil_dx)
-    deallocate(soil_dy)
-    deallocate(soil_dz)
-    deallocate(soil_area)
-    deallocate(soil_filter)  
+    deallocate(mesh)
 
   end subroutine add_meshes
 

--- a/src/mpp/dtypes/ConditionType.F90
+++ b/src/mpp/dtypes/ConditionType.F90
@@ -399,7 +399,6 @@ contains
     ! Release all allocated memory
     !
     ! !USES:
-    use ConnectionSetType  , only : ConnectionSetDestroy
     !
     implicit none
     !
@@ -416,7 +415,8 @@ contains
     if (associated(cond%value)) deallocate(cond%value)
     nullify(cond%value)
 
-    call ConnectionSetDestroy(cond%conn_set)
+    call cond%conn_set%Destroy()
+
     nullify(cond%conn_set)
 
   end subroutine ConditionDestroy

--- a/src/mpp/dtypes/ConnectionSetType.F90
+++ b/src/mpp/dtypes/ConnectionSetType.F90
@@ -49,7 +49,7 @@ module ConnectionSetType
      PetscInt                           :: num_connections    ! total num. of connections
      PetscInt                           :: num_active_conn    ! number of active connections
      PetscInt                 , pointer :: active_conn_ids(:) ! IDs of active connection
-     type(connection_type)    , pointer :: conn(:)            ! information about all connections
+     class(connection_type)    , pointer :: conn(:)            ! information about all connections
      class(connection_set_type), pointer :: next
    contains
      procedure, public :: SetActiveConnections => ConnSetSetActiveConnections
@@ -60,8 +60,8 @@ module ConnectionSetType
 
   type, public :: connection_set_list_type
      PetscInt                           :: num_connection_list
-     type(connection_set_type), pointer :: first
-     type(connection_set_type), pointer :: last
+     class(connection_set_type), pointer :: first
+     class(connection_set_type), pointer :: last
    contains
      procedure, public :: Init   => ConnectionSetListInit
      procedure, public :: AddSet => ConnectionSetListAddSet

--- a/src/mpp/dtypes/GoverningEquationBaseType.F90
+++ b/src/mpp/dtypes/GoverningEquationBaseType.F90
@@ -599,7 +599,6 @@ contains
     use MultiPhysicsProbConstants , only : COND_BC
     use MultiPhysicsProbConstants , only : COND_SS
     use ConnectionSetType         , only : ConnectionSetNew
-    use ConnectionSetType         , only : ConnectionSetDestroy
     !
     implicit none
     !
@@ -668,7 +667,7 @@ contains
 
     end select
 
-    call ConnectionSetDestroy(cond%conn_set)
+    call cond%conn_set%Destroy()
 
     allocate(cond%conn_set)
     cond%conn_set => ConnectionSetNew(nconn)

--- a/src/mpp/dtypes/MultiPhysicsProbBaseType.F90
+++ b/src/mpp/dtypes/MultiPhysicsProbBaseType.F90
@@ -62,6 +62,7 @@ module MultiPhysicsProbBaseType
      procedure, public :: GovEqnSetInternalCouplingVars => MPPGovEqnSetInternalCouplingVars
      procedure, public :: GovEqnSetBothCouplingVars     => MPPGovEqnSetBothCouplingVars
      procedure, public :: GovEqnAddCouplingCondition    => MPPGovEqnAddCouplingCondition
+     procedure, public :: AddMesh                       => MPPAddMesh
   end type multiphysicsprob_base_type
 
   public :: MPPBaseInit
@@ -160,6 +161,21 @@ contains
     enddo
 
   end subroutine MPPSetNumMeshes
+
+  !------------------------------------------------------------------------
+  subroutine MPPAddMesh(this, imesh, mesh)
+    !
+    implicit none
+    !
+    ! !ARGUMENTS
+    class(multiphysicsprob_base_type) :: this
+    PetscInt                          :: imesh
+    class(mesh_type), pointer         :: mesh
+
+    call CheckMeshIndex(this, imesh)
+    call this%meshes(imesh)%Copy(mesh)
+
+  end subroutine MPPAddMesh
 
   !------------------------------------------------------------------------
   subroutine MPPSetID(this, id)

--- a/src/mpp/thermal-e/GoveqnThermalEnthalpySoilType.F90
+++ b/src/mpp/thermal-e/GoveqnThermalEnthalpySoilType.F90
@@ -940,7 +940,7 @@ contains
     PetscInt                                 :: sum_conn
     PetscReal                                :: temperature
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     character(len=256)                       :: string
 
     ! Update aux vars for boundary cells
@@ -992,7 +992,7 @@ contains
     PetscInt                                 :: iconn
     PetscInt                                 :: sum_conn
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
 
     ! Update aux vars for source/sink cells
     sum_conn = 0
@@ -1278,7 +1278,7 @@ contains
     !
     ! !LOCAL VARIABLES
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscInt                                 :: iconn
     PetscInt                                 :: sum_conn
     PetscInt                                 :: cell_id_dn
@@ -1499,7 +1499,7 @@ contains
     !
     ! !LOCAL VARIABLES
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscInt                                 :: iconn
     PetscInt                                 :: sum_conn
     PetscInt                                 :: cell_id_dn
@@ -1737,7 +1737,7 @@ contains
     !
     ! !LOCAL VARIABLES
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscInt                                 :: ieqn
     PetscInt                                 :: iconn
     PetscInt                                 :: sum_conn
@@ -1875,7 +1875,7 @@ contains
     ! !LOCAL VARIABLES
     type (therm_enthalpy_soil_auxvar_type) , pointer :: aux_vars(:)
     type(condition_type)                   , pointer :: cur_cond
-    type(connection_set_type)              , pointer :: cur_conn_set
+    class(connection_set_type)             , pointer :: cur_conn_set
     type(coupling_variable_type)           , pointer :: cpl_var
     PetscInt                                         :: iconn
     PetscInt                                         :: ieqn

--- a/src/mpp/thermal/GoveqnThermalKSPTemperatureSSWType.F90
+++ b/src/mpp/thermal/GoveqnThermalKSPTemperatureSSWType.F90
@@ -257,7 +257,7 @@ contains
     integer                                                       :: condition_id, sum_conn
     integer                                                       :: cell_id
     type(condition_type), pointer                                 :: cur_cond
-    type(connection_set_type), pointer                            :: cur_conn_set
+    class(connection_set_type), pointer                           :: cur_conn_set
     character(len=256)                                            :: string
 
     auxVarCt_ge = size(this%aux_vars_bc)
@@ -347,7 +347,7 @@ contains
     integer                                                       :: condition_id, sum_conn
     PetscReal                                                     :: var_value
     type(condition_type), pointer                                 :: cur_cond
-    type(connection_set_type), pointer                            :: cur_conn_set
+    class(connection_set_type), pointer                           :: cur_conn_set
     character(len=256)                                            :: string
 
     auxVarCt_ge = size(this%aux_vars_ss)
@@ -561,7 +561,7 @@ contains
     class(goveqn_thermal_ksp_temp_ssw_type)        :: this
     !
     ! !LOCAL VARIABLES
-    type(connection_set_type), pointer             :: conn_set
+    class(connection_set_type), pointer            :: conn_set
     PetscInt                                       :: cell_id
     PetscInt                                       :: ieqn
     PetscInt                                       :: iconn
@@ -686,7 +686,7 @@ contains
     PetscReal                                  :: coeff
     PetscReal                                  :: value
     PetscReal                                  :: factor
-    type(connection_set_type), pointer         :: cur_conn_set
+    class(connection_set_type), pointer        :: cur_conn_set
     type(condition_type),pointer               :: cur_cond
 
     dt = this%dtime
@@ -824,7 +824,7 @@ contains
     PetscReal                                  :: dt, factor
     PetscReal                                  :: therm_cond_aveg, therm_cond_up, therm_cond_dn
     PetscReal                                  :: coeff
-    type(connection_set_type), pointer         :: cur_conn_set
+    class(connection_set_type), pointer        :: cur_conn_set
     type(condition_type),pointer               :: cur_cond
 
     dt = this%dtime
@@ -958,7 +958,7 @@ contains
     PetscReal                                :: area, vol, dt
     PetscReal                                :: heat_cap, factor
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscReal                                :: dist, dist_up, dist_dn
     PetscReal                                :: therm_cond_aveg, therm_cond_up, therm_cond_dn
     PetscReal                                :: T_up, T_dn

--- a/src/mpp/thermal/GoveqnThermalKSPTemperatureSnowType.F90
+++ b/src/mpp/thermal/GoveqnThermalKSPTemperatureSnowType.F90
@@ -548,7 +548,7 @@ contains
     class(goveqn_thermal_ksp_temp_snow_type) :: this
     !
     ! !LOCAL VARIABLES
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscInt                                 :: icell
     PetscInt                                 :: cell_id_up
     PetscInt                                 :: cell_id_dn
@@ -596,7 +596,7 @@ contains
     class(goveqn_thermal_ksp_temp_snow_type) :: this
     !
     ! !LOCAL VARIABLES
-    type(connection_set_type), pointer       :: conn_set
+    class(connection_set_type), pointer      :: conn_set
     PetscInt                                 :: ieqn
     PetscInt                                 :: iconn
     PetscInt                                 :: cell_id
@@ -791,7 +791,7 @@ contains
     PetscReal                          :: dt
     PetscReal                          :: area, heat_cap, tfactor, vol, factor
     type(condition_type),pointer       :: cur_cond
-    type(connection_set_type), pointer :: cur_conn_set
+    class(connection_set_type), pointer:: cur_conn_set
 
     dt = geq_snow%dtime
 
@@ -1008,7 +1008,7 @@ contains
     PetscReal                                  :: dhsdT
     PetscReal                                  :: dt
     PetscReal                                  :: value, factor
-    type(connection_set_type), pointer         :: cur_conn_set
+    class(connection_set_type), pointer        :: cur_conn_set
     type(condition_type),pointer               :: cur_cond
 
     dt = this%dtime
@@ -1198,7 +1198,7 @@ contains
     PetscReal                                :: tfactor
     PetscReal                                :: dt
     PetscReal                                :: value
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     type(condition_type),pointer             :: cur_cond
     PetscReal                                :: factor
     PetscReal                                :: T

--- a/src/mpp/thermal/GoveqnThermalKSPTemperatureSoilType.F90
+++ b/src/mpp/thermal/GoveqnThermalKSPTemperatureSoilType.F90
@@ -710,7 +710,7 @@ contains
     PetscReal                                :: flux
     PetscReal                                :: area
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscReal                                :: factor
     PetscReal                                :: T
     PetscReal                                :: dt
@@ -1011,7 +1011,7 @@ contains
     PetscReal                                :: frac
     PetscReal                                :: dt
     PetscReal                                :: value
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     type(condition_type),pointer             :: cur_cond
     PetscReal :: factor
     PetscReal                                :: T
@@ -1240,7 +1240,7 @@ contains
     PetscReal                                :: vol
     PetscReal                                :: dt
     PetscBool                                :: is_bc_sh2o
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     type(condition_type)     , pointer       :: cur_cond
 
     dt = this%dtime
@@ -1349,7 +1349,7 @@ contains
     PetscBool                                :: is_bc_snow
     PetscBool                                :: is_bc_sh2o
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
       
     ! Boundary cells
     cur_cond => this%boundary_conditions%first

--- a/src/mpp/util/CMakeLists.txt
+++ b/src/mpp/util/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MPP_UTIL_SOURCES
   MultiPhysicsProbConstants.F90
   mpp_abortutils.F90
   mpp_bounds.F90
+  mpp_mesh_utils.F90
   mpp_shr_log_mod.F90
   mpp_varcon.F90
   mpp_varctl.F90

--- a/src/mpp/util/MultiPhysicsProbConstants.F90
+++ b/src/mpp/util/MultiPhysicsProbConstants.F90
@@ -141,6 +141,10 @@ module MultiPhysicsProbConstants
   PetscInt, parameter, public :: CONN_HORIZONTAL                   = 902
   PetscInt, parameter, public :: CONN_SET_INTERNAL                 = 903
   PetscInt, parameter, public :: CONN_SET_LATERAL                  = 904
+  PetscInt, parameter, public :: CONN_IN_X_DIR                     = 905
+  PetscInt, parameter, public :: CONN_IN_Y_DIR                     = 906
+  PetscInt, parameter, public :: CONN_IN_Z_DIR                     = 907
+  PetscInt, parameter, public :: CONN_IN_XYZ_DIR                   = 908
 
   PetscInt, parameter, public :: DARCY_FLUX_TYPE                   = 1001
   PetscInt, parameter, public :: CONDUCTANCE_FLUX_TYPE             = 1002

--- a/src/mpp/util/mpp_mesh_utils.F90
+++ b/src/mpp/util/mpp_mesh_utils.F90
@@ -1,0 +1,735 @@
+module mpp_mesh_utils
+
+#include <petsc/finclude/petsc.h>
+
+  use petscsys
+  use mpp_varctl              , only : iulog
+  use mpp_abortutils          , only : endrun
+  use mpp_shr_log_mod         , only : errMsg => shr_log_errMsg
+
+  implicit none
+
+  public :: ComputeXYZCentroids
+  public :: ComputeCentroids
+  public :: ComputeInternalConnections
+
+  interface ComputeXYZCentroids
+     procedure ComputeXYZCentroids1
+     procedure ComputeXYZCentroids2
+     procedure ComputeXYZCentroids3
+     procedure ComputeXYZCentroids4
+  end interface ComputeXYZCentroids
+
+  interface ComputeCentroids
+     procedure ComputeCentroids1
+     procedure ComputeCentroids2
+  end interface ComputeCentroids
+
+contains
+
+  !------------------------------------------------------------------------
+  subroutine ComputeXYZCentroids1( &
+       nx, ny, nz,                  &
+       dx, dy, dz,                  &
+       x_min, y_min, z_min,         &
+       xc, yc, zc)
+    !
+    ! !DESCRIPTION:
+    ! Computes centroids along X, Y, and Z direction for a structured
+    ! grid that has spatially homogeneous dx, dy, and dz. Returns values
+    ! in a 1D array.
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : VAR_XC, VAR_YC, VAR_ZC
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dx, dy, dz
+    PetscReal, intent(in)           :: x_min, y_min, z_min
+    PetscReal, intent(out), pointer :: xc(:), yc(:), zc(:)
+    !
+    PetscInt :: ii, jj, kk
+    PetscInt :: count
+
+    allocate(xc(nx*ny*nz))
+    allocate(yc(nx*ny*nz))
+    allocate(zc(nx*ny*nz))
+
+    write(*,*)'call ComputeCentroids: ',x_min
+    call ComputeCentroids(nx, ny, nz, dx, x_min, VAR_XC, xc)
+    call ComputeCentroids(nx, ny, nz, dy, y_min, VAR_YC, yc)
+    call ComputeCentroids(nx, ny, nz, dz, z_min, VAR_ZC, zc)
+
+  end subroutine ComputeXYZCentroids1
+
+  !------------------------------------------------------------------------
+  subroutine ComputeXYZCentroids2( &
+       nx, ny, nz,                  &
+       dx, dy, dz,                  &
+       xc, yc, zc)
+    !
+    ! !DESCRIPTION:
+    ! Computes centroids along X, Y, and Z direction for a structured
+    ! grid that has spatially homogeneous dx, dy, and dz. Returns values
+    ! in a 1D array.
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : VAR_XC, VAR_YC, VAR_ZC
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dx, dy, dz
+    PetscReal, intent(out), pointer :: xc(:), yc(:), zc(:)
+
+    call ComputeXYZCentroids( &
+         nx = nx, ny = ny, nz = nz, &
+         dx = dx, dy = dy, dz = dz, &
+         x_min = 0.d0, y_min = 0.d0, z_min = 0.d0, &
+         xc = xc, yc = yc, zc = zc)
+    
+  end subroutine ComputeXYZCentroids2
+
+  !------------------------------------------------------------------------
+  subroutine ComputeXYZCentroids3( &
+       nx, ny, nz,                 &
+       dx, dy, dz,                 &
+       x_min, y_min, z_min,        &
+       xc, yc, zc)
+    !
+    ! !DESCRIPTION:
+    ! Same as ComputeXYZCentroids1D except returns values in a 1D array.
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : VAR_XC, VAR_YC, VAR_ZC
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dx, dy, dz
+    PetscReal, intent(in)           :: x_min, y_min, z_min
+    PetscReal, intent(out), pointer :: xc(:,:,:), yc(:,:,:), zc(:,:,:)
+    !
+    PetscInt                        :: ii, jj, kk
+    PetscReal, pointer              :: xc_1D(:), yc_1D(:), zc_1D(:)
+
+    allocate(xc(nx,ny,nz))
+    allocate(yc(nx,ny,nz))
+    allocate(zc(nx,ny,nz))
+    
+    call ComputeXYZCentroids( &
+         nx = nx, ny = ny, nz = nz, &
+         dx = dx, dy = dy, dz = dz, &
+         x_min = x_min, y_min = y_min, z_min = z_min, &
+         xc = xc_1D, yc = yc_1D, zc = zc_1D)
+    
+    call Remap1Dto3D(nx, ny, nz, xc_1D, xc)
+    call Remap1Dto3D(nx, ny, nz, yc_1D, yc)
+    call Remap1Dto3D(nx, ny, nz, zc_1D, zc)
+
+    deallocate(xc_1D)
+    deallocate(yc_1D)
+    deallocate(zc_1D)
+
+  end subroutine ComputeXYZCentroids3
+
+  !------------------------------------------------------------------------
+  subroutine ComputeXYZCentroids4( &
+       nx, ny, nz,                 &
+       dx, dy, dz,                 &
+       xc, yc, zc)
+    !
+    ! !DESCRIPTION:
+    ! Same as ComputeXYZCentroids1D except returns values in a 1D array.
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : VAR_XC, VAR_YC, VAR_ZC
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dx, dy, dz
+    PetscReal, intent(out), pointer :: xc(:,:,:), yc(:,:,:), zc(:,:,:)
+    !
+    PetscInt                        :: ii, jj, kk
+
+    call ComputeXYZCentroids( &
+         nx = nx, ny = ny, nz = nz, &
+         dx = dx, dy = dy, dz = dz, &
+         x_min = 0.d0, y_min = 0.d0, z_min = 0.d0, &
+         xc = xc, yc = yc, zc = zc)
+    
+  end subroutine ComputeXYZCentroids4
+
+  !------------------------------------------------------------------------
+  subroutine ComputeCentroids1(nx, ny, nz, &
+       dd, dmin, idir, &
+       dc)
+    !
+    ! !DESCRIPTION:
+    ! Computes centroids along 'idir' direction for a structured
+    ! grid that has spatially homogeneous dx, dy, and dz. Returns
+    ! values in a 1D array.
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : VAR_XC, VAR_YC, VAR_ZC
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dd, dmin
+    PetscInt , intent(in)           :: idir
+    PetscReal, intent(out), pointer :: dc(:)
+    !
+    PetscInt :: ii, jj, kk
+    PetscInt :: index
+    PetscInt :: count
+
+    count = 0
+    do kk = 1,nz
+       do jj = 1,ny
+          do ii = 1, nx
+             count = count + 1
+
+             select case (idir)
+             case (VAR_XC)
+                index = ii
+             case (VAR_YC)
+                index = jj
+             case (VAR_ZC)
+                index = kk
+             end select
+
+             dc(count) = dd/2.d0 + dd * (index - 1) + dmin
+          end do
+       end do
+    end do
+
+  end subroutine ComputeCentroids1
+
+  !------------------------------------------------------------------------
+  subroutine ComputeCentroids2(nx, ny, nz, &
+       dd, dmin, idir, &
+       dc)
+    !
+    ! !DESCRIPTION:
+    ! Similar to ComputeCentroids1D except returns values in a 3D array.
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : VAR_XC, VAR_YC, VAR_ZC
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dd, dmin
+    PetscInt , intent(in)           :: idir
+    PetscReal, intent(out), pointer :: dc(:,:,:)
+    !
+    PetscReal, pointer              :: dc_1D(:)
+
+    allocate(dc_1D(nx*ny*nz))
+
+    call ComputeCentroids1(nx, ny, nz, &
+       dd, dmin, idir, dc_1D)
+
+    call Remap1Dto3D(nx, ny, nz, dc_1D, dc)
+
+    deallocate(dc_1D)
+
+  end subroutine ComputeCentroids2
+
+  !------------------------------------------------------------------------
+  subroutine ComputeInternalConnections(nx, ny, nz, &
+       dx, dy, dz, idir, &
+       nconn, conn_id_up, conn_id_dn, conn_dist_up, conn_dist_dn, &
+       conn_area, conn_type)
+    !
+    ! !DESCRIPTION:
+    ! Sets up connection set along 'idir' direction
+    ! for a structured grid that has spatially homogeneous
+    ! dx, dy, and dz
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : CONN_IN_X_DIR
+    use MultiPhysicsProbConstants, only : CONN_IN_Y_DIR
+    use MultiPhysicsProbConstants, only : CONN_IN_Z_DIR
+    use MultiPhysicsProbConstants, only : CONN_IN_XYZ_DIR
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dx, dy, dz
+    PetscInt , intent(in)           :: idir
+    PetscInt , intent(out)          :: nconn
+    PetscInt , intent(out), pointer :: conn_id_up(:), conn_id_dn(:)
+    PetscReal, intent(out), pointer :: conn_dist_up(:), conn_dist_dn(:)
+    PetscReal, intent(out), pointer :: conn_area(:)
+    PetscInt , intent(out), pointer :: conn_type(:)
+    !
+    PetscInt                        :: iconn
+
+    select case(idir)
+    case (CONN_IN_X_DIR)
+       nconn = (nx-1)*ny*nz
+       
+    case (CONN_IN_Y_DIR)
+       nconn = nx*(ny-1)*nz
+       
+    case (CONN_IN_Z_DIR)
+       nconn = nx*ny*(nz-1)
+       
+    case (CONN_IN_XYZ_DIR)
+       nconn = &
+            (nx-1)* ny   *nz    + & ! connections in x-dir
+            nx   *(ny-1)*nz     + & ! connections in y-dir
+            nx   * ny   *(nz-1)     ! connections in z-dir
+    case default
+       write(iulog,*)'Unsupported idir'
+       call endrun(msg=errMsg(__FILE__,__LINE__))
+    end select
+    
+    allocate(conn_id_up   (nconn))
+    allocate(conn_id_dn   (nconn))
+    allocate(conn_dist_up (nconn))
+    allocate(conn_dist_dn (nconn))
+    allocate(conn_area    (nconn))
+    allocate(conn_type    (nconn))
+
+    iconn = 0
+    select case(idir)
+    case (CONN_IN_X_DIR)
+       call ComputeIntConnAlongADirection( &
+            nx, ny, nz, dx, dy, dz,        &
+            iconn, CONN_IN_X_DIR,          &
+            conn_id_up, conn_id_dn,        &
+            conn_dist_up, conn_dist_dn,    &
+            conn_area, conn_type)
+
+    case (CONN_IN_Y_DIR)
+       call ComputeIntConnAlongADirection( &
+            nx, ny, nz, dx, dy, dz,        &
+            iconn, CONN_IN_Y_DIR,          &
+            conn_id_up, conn_id_dn,        &
+            conn_dist_up, conn_dist_dn,    &
+            conn_area, conn_type)
+       
+    case (CONN_IN_Z_DIR)
+       call ComputeIntConnAlongADirection( &
+            nx, ny, nz, dx, dy, dz,        &
+            iconn, CONN_IN_Z_DIR,          &
+            conn_id_up, conn_id_dn,        &
+            conn_dist_up, conn_dist_dn,    &
+            conn_area, conn_type)
+       
+    case (CONN_IN_XYZ_DIR)
+       call ComputeIntConnAlongADirection( &
+            nx, ny, nz, dx, dy, dz,        &
+            iconn, CONN_IN_X_DIR,          &
+            conn_id_up, conn_id_dn,        &
+            conn_dist_up, conn_dist_dn,    &
+            conn_area, conn_type)
+
+       call ComputeIntConnAlongADirection( &
+            nx, ny, nz, dx, dy, dz,        &
+            iconn, CONN_IN_Y_DIR,          &
+            conn_id_up, conn_id_dn,        &
+            conn_dist_up, conn_dist_dn,    &
+            conn_area, conn_type)
+
+       call ComputeIntConnAlongADirection( &
+            nx, ny, nz, dx, dy, dz,        &
+            iconn, CONN_IN_Z_DIR,          &
+            conn_id_up, conn_id_dn,        &
+            conn_dist_up, conn_dist_dn,    &
+            conn_area, conn_type)
+
+    case default
+       write(iulog,*)'Unsupported idir'
+       call endrun(msg=errMsg(__FILE__,__LINE__))
+    end select
+
+  end subroutine ComputeInternalConnections
+
+  !------------------------------------------------------------------------
+  subroutine ComputeIntConnAlongADirection(nx, ny, nz, &
+       dx, dy, dz, &
+       iconn, idir, &
+       conn_id_up, conn_id_dn, conn_dist_up, conn_dist_dn, &
+       conn_area, conn_type)
+    !
+    ! !DESCRIPTION:
+    ! Sets up connection along either x, y, or z-direction
+    ! for a structured grid that has spatially homogeneous
+    ! dx, dy, and dz
+    !
+    ! !USES:
+    use MultiPhysicsProbConstants, only : CONN_IN_X_DIR
+    use MultiPhysicsProbConstants, only : CONN_IN_Y_DIR
+    use MultiPhysicsProbConstants, only : CONN_IN_Z_DIR
+    use MultiPhysicsProbConstants, only : CONN_HORIZONTAL
+    use MultiPhysicsProbConstants, only : CONN_VERTICAL
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(in)           :: dx, dy, dz
+    PetscInt , intent(inout)        :: iconn
+    PetscInt , intent(in)           :: idir
+    PetscInt , intent(out), pointer :: conn_id_up(:), conn_id_dn(:)
+    PetscReal, intent(out), pointer :: conn_dist_up(:), conn_dist_dn(:)
+    PetscReal, intent(out), pointer :: conn_area(:)
+    PetscInt , intent(out), pointer :: conn_type(:)
+    !
+    PetscInt, pointer               :: id(:,:,:)
+    PetscInt                        :: count
+    PetscInt                        :: ii, jj, kk
+    PetscInt                        :: ii_offset, jj_offset, kk_offset
+    PetscInt                        :: ii_max, jj_max, kk_max
+    PetscInt                        :: ii_up, jj_up, kk_up
+    PetscInt                        :: ii_dn, jj_dn, kk_dn
+    PetscReal                       :: dist, area
+    PetscInt                        :: itype
+
+    ! Compute cell ids
+    call ComputeCellID(nx, ny, nz, id)
+    
+    ! Default value for offset & max value for all direction
+    ii_offset = 0; ii_max = nx
+    jj_offset = 0; jj_max = ny
+    kk_offset = 0; kk_max = nz
+
+    ! Update value for offset & max value depending on the direction
+    ! of connection set
+    ! For a connection set in x-dir, ii index will loop over 1:nx-1 and
+    ! cell ids of connections will be between ii and ii+1
+    !
+    select case (idir)
+    case (CONN_IN_X_DIR)
+       ii_offset = 1; ii_max = nx-1
+
+    case (CONN_IN_Y_DIR)
+       jj_offset = 1; jj_max = ny-1
+
+    case (CONN_IN_Z_DIR)
+       kk_offset = 1; kk_max = nz-1
+
+    case default
+       write(iulog,*)'Unsupported idir'
+       call endrun(msg=errMsg(__FILE__,__LINE__))
+   end select
+
+    do ii = 1, ii_max
+       do jj = 1, jj_max
+          do kk = 1, kk_max
+
+             iconn = iconn + 1
+             ii_up = ii; ii_dn = ii + ii_offset
+             jj_up = jj; jj_dn = jj + jj_offset
+             kk_up = kk; kk_dn = kk + kk_offset
+
+             conn_id_up(iconn)   = id(ii_up, jj_up, kk_up)
+             conn_id_dn(iconn)   = id(ii_dn, jj_dn, kk_dn)
+
+             select case (idir)
+             case (CONN_IN_X_DIR)
+                dist      = dx
+                area      = dy*dz
+                itype = CONN_HORIZONTAL
+
+             case (CONN_IN_Y_DIR)
+                dist      = dy
+                area      = dx*dz
+                itype = CONN_HORIZONTAL
+
+             case (CONN_IN_Z_DIR)
+                dist      = dz
+                area      = dx*dy
+                itype = CONN_VERTICAL
+             end select
+
+             conn_dist_up(iconn) = 0.5d0*dist
+             conn_dist_dn(iconn) = 0.5d0*dist
+             conn_area(iconn)    = area
+             conn_type(iconn)    = CONN_HORIZONTAL !itype
+
+          end do
+       end do
+    end do
+
+    deallocate(id)
+
+  end subroutine ComputeIntConnAlongADirection
+
+  !------------------------------------------------------------------------
+  subroutine ComputeBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       nconn, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    !
+    implicit none
+    !
+    PetscInt  , intent(in)  :: nx, ny, nz
+    PetscReal , intent(in)  :: dx, dy, dz
+    PetscInt  , intent(out) :: nconn
+    PetscInt  , pointer     :: id_up    (:)
+    PetscInt  , pointer     :: id_dn    (:)
+    PetscReal , pointer     :: dist_up  (:)
+    PetscReal , pointer     :: dist_dn  (:)
+    PetscReal , pointer     :: area     (:)
+    PetscInt  , pointer     :: itype    (:)
+    PetscInt  , pointer     :: tmp_3d   (:,:,:)
+    PetscReal , pointer     :: unit_vec (:,:)
+    !
+    PetscInt                :: iconn
+    PetscInt                :: count
+  
+    nconn = 0
+
+    if (nx > 1) nconn = nconn + ny*nz*2
+    if (ny > 1) nconn = nconn + nx*nz*2
+    if (nz > 1) nconn = nconn + nx*ny*2
+        
+    allocate(id_up    (nconn ))
+    allocate(id_dn    (nconn ))
+    allocate(dist_up  (nconn ))
+    allocate(dist_dn  (nconn ))
+    allocate(area     (nconn ))
+    allocate(itype    (nconn ))
+    allocate(unit_vec (nconn,3 ))
+
+    count = 0
+    call ComputeXBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       count, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    
+    call ComputeYBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       count, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    
+    call ComputeZBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       count, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    
+  end subroutine ComputeBoundaryDomainConnection
+
+  !------------------------------------------------------------------------
+  subroutine ComputeXBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       count, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    !
+    use MultiPhysicsProbConstants, only : CONN_HORIZONTAL
+    use MultiPhysicsProbConstants, only : CONN_VERTICAL
+    !
+    implicit none
+    !
+    PetscInt  , intent(in)  :: nx, ny, nz
+    PetscReal , intent(in)  :: dx, dy, dz
+    PetscInt  , intent(inout) :: count
+    PetscInt  , pointer     :: id_up    (:)
+    PetscInt  , pointer     :: id_dn    (:)
+    PetscReal , pointer     :: dist_up  (:)
+    PetscReal , pointer     :: dist_dn  (:)
+    PetscReal , pointer     :: area     (:)
+    PetscInt  , pointer     :: itype    (:)
+    PetscReal , pointer     :: unit_vec (:,:)
+    !
+    PetscInt :: ii, jj, kk
+    PetscInt, pointer               :: id(:,:,:)
+
+    ! Compute cell ids
+    call ComputeCellID(nx, ny, nz, id)
+
+    ! X-direction
+    if (nx > 1) then
+       id_up(:) = 0
+       
+       do kk = 1,nz
+          do jj = 1,ny
+
+             ! At the beginning
+             ii = 1;
+             count             = count + 1
+             id_dn(count)      = id(ii,jj,kk)
+             dist_up(count)    = dx/2.d0*0.d0
+             dist_dn(count)    = dx/2.d0
+             area(count)       = dy*dz
+             unit_vec(count,1) = 1.d0
+             itype(count)      = CONN_HORIZONTAL
+
+             ! At the end
+             ii = nx
+             count             = count + 1
+             id_dn(count)      = id(ii,jj,kk)
+             dist_up(count)    = dx/2.d0*0.d0
+             dist_dn(count)    = dx/2.d0
+             area(count)       = dy*dz
+             unit_vec(count,1) = -1.d0
+             itype(count)      = CONN_HORIZONTAL
+          end do
+       end do
+    end if
+
+  end subroutine ComputeXBoundaryDomainConnection
+
+  !------------------------------------------------------------------------
+  subroutine ComputeYBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       count, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    !
+    use MultiPhysicsProbConstants, only : CONN_HORIZONTAL
+    use MultiPhysicsProbConstants, only : CONN_VERTICAL
+    !
+    implicit none
+    !
+    PetscInt  , intent(in)  :: nx, ny, nz
+    PetscReal , intent(in)  :: dx, dy, dz
+    PetscInt  , intent(inout) :: count
+    PetscInt  , pointer     :: id_up    (:)
+    PetscInt  , pointer     :: id_dn    (:)
+    PetscReal , pointer     :: dist_up  (:)
+    PetscReal , pointer     :: dist_dn  (:)
+    PetscReal , pointer     :: area     (:)
+    PetscInt  , pointer     :: itype    (:)
+    PetscReal , pointer     :: unit_vec (:,:)
+    !
+    PetscInt :: ii, jj, kk
+    PetscInt, pointer               :: id(:,:,:)
+
+    ! Compute cell ids
+    call ComputeCellID(nx, ny, nz, id)
+
+    ! Y-direction
+    if (ny > 1) then
+       id_up(:) = 0
+       
+       do kk = 1,nz
+          do ii = 1,nx
+
+             ! At the beginning
+             jj = 1;
+             count             = count + 1
+             id_dn(count)      = id(ii,jj,kk)
+             dist_up(count)    = 0.d0
+             dist_dn(count)    = dy/2.d0
+             area(count)       = dx*dz
+             unit_vec(count,1) = 1.d0
+             itype(count)      = CONN_HORIZONTAL
+
+             ! At the end
+             jj = ny
+             count             = count + 1
+             id_dn(count)      = id(ii,jj,kk)
+             dist_up(count)    = 0.d0
+             dist_dn(count)    = dy/2.d0
+             area(count)       = dx*dz
+             unit_vec(count,1) = -1.d0
+             itype(count)      = CONN_HORIZONTAL
+          end do
+       end do
+    end if
+
+  end subroutine ComputeYBoundaryDomainConnection
+
+  !------------------------------------------------------------------------
+  subroutine ComputeZBoundaryDomainConnection(nx, ny, nz, dx, dy, dz, &
+       count, id_up, id_dn, dist_up, dist_dn, area, itype, unit_vec)
+    !
+    use MultiPhysicsProbConstants, only : CONN_HORIZONTAL
+    use MultiPhysicsProbConstants, only : CONN_VERTICAL
+    !
+    implicit none
+    !
+    PetscInt       , intent(in)    :: nx, ny, nz
+    PetscReal      , intent(in)    :: dx, dy, dz
+    PetscInt       , intent(inout) :: count
+    PetscInt       , pointer       :: id_up    (:)
+    PetscInt       , pointer       :: id_dn    (:)
+    PetscReal      , pointer       :: dist_up  (:)
+    PetscReal      , pointer       :: dist_dn  (:)
+    PetscReal      , pointer       :: area     (:)
+    PetscInt       , pointer       :: itype    (:)
+    PetscReal      , pointer       :: unit_vec (:,:)
+    !
+    PetscInt                       :: ii , jj, kk
+    PetscInt       , pointer       :: id(:,:,:)
+
+    ! Compute cell ids
+    call ComputeCellID(nx, ny, nz, id)
+
+    ! Z-direction
+    if (nz > 1) then
+       id_up(:) = 0
+       
+       do jj = 1,ny
+          do ii = 1,nx
+
+             ! At the beginning
+             kk = 1;
+             count             = count + 1
+             id_dn(count)      = id(ii,jj,kk)
+             dist_up(count)    = 0.d0
+             dist_dn(count)    = dz/2.d0
+             area(count)       = dx*dy
+             unit_vec(count,1) = 1.d0
+             itype(count)      = CONN_VERTICAL
+
+             ! At the end
+             kk = nz
+             count             = count + 1
+             id_dn(count)      = id(ii,jj,kk)
+             dist_up(count)    = 0.d0
+             dist_dn(count)    = dz/2.d0
+             area(count)       = dx*dy
+             unit_vec(count,1) = -1.d0
+             itype(count)      = CONN_VERTICAL
+          end do
+       end do
+    end if
+
+  end subroutine ComputeZBoundaryDomainConnection
+
+  !------------------------------------------------------------------------
+  subroutine ComputeCellID(nx, ny, nz, id)
+    !
+    implicit none
+    !
+    PetscInt, intent(in)           :: nx, ny, nz
+    PetscInt, intent(out), pointer :: id(:,:,:)
+    !
+    PetscInt :: ii, jj, kk
+    PetscInt :: count
+    
+    allocate(id(nx,ny,nz))
+      
+    ! Determine ID of control volumes
+    count = 0
+    do kk = 1, nz
+       do jj = 1, ny
+          do ii = 1, nx
+             count = count + 1
+             id(ii,jj,kk) = count
+          end do
+       end do
+    end do
+
+  end subroutine ComputeCellID
+
+  !------------------------------------------------------------------------
+  subroutine Remap1Dto3D(nx, ny, nz, data_1D, data_3D)
+    !
+    implicit none
+    !
+    PetscInt , intent(in)           :: nx, ny, nz
+    PetscReal, intent(out), pointer :: data_1D(:)
+    PetscReal, intent(out), pointer :: data_3D(:,:,:)
+    !
+    PetscInt :: ii, jj, kk
+    PetscInt :: count
+    
+    count = 0
+    do kk = 1, nz
+       do jj = 1, ny
+          do ii = 1, nx
+             count = count + 1
+             data_3D(ii,jj,kk) = data_1D(count)
+          end do
+       end do
+    end do
+
+  end subroutine Remap1Dto3D
+
+end module mpp_mesh_utils

--- a/src/mpp/vsfm/GoveqnRichardsODEPressureType.F90
+++ b/src/mpp/vsfm/GoveqnRichardsODEPressureType.F90
@@ -124,7 +124,7 @@ contains
     class(goveqn_richards_ode_pressure_type) :: this
     !
     type(condition_type)      , pointer      :: cur_cond
-    type(connection_set_type) , pointer      :: cur_conn_set
+    class(connection_set_type) , pointer     :: cur_conn_set
     PetscInt                                 :: ncells_cond
     PetscInt                                 :: sum_conn
     PetscInt                                 :: icond
@@ -641,7 +641,7 @@ contains
     integer                                                             :: sum_conn
     type(rich_ode_pres_auxvar_type)          , dimension(:), pointer    :: ge_avars
     type(condition_type)                     , pointer                  :: cur_cond
-    type(connection_set_type)                , pointer                  :: cur_conn_set
+    class(connection_set_type)               , pointer                  :: cur_conn_set
     character(len=256)                                                  :: string
     PetscInt                                                            :: num_bc
     PetscInt                                                            :: icond
@@ -752,7 +752,7 @@ contains
     PetscReal                                                  :: var_value
     type(rich_ode_pres_auxvar_type), dimension(:), pointer     :: ge_avars
     type(condition_type), pointer                              :: cur_cond
-    type(connection_set_type), pointer                         :: cur_conn_set
+    class(connection_set_type), pointer                        :: cur_conn_set
     character(len=256)                                         :: string
 
     ge_avars => this%aux_vars_ss
@@ -927,7 +927,7 @@ contains
     PetscInt, pointer                                              :: ncells_for_bc(:)
     character(len=256)                                             :: string
     type(condition_type), pointer                                  :: cur_cond
-    type(connection_set_type), pointer                             :: cur_conn_set
+    class(connection_set_type), pointer                            :: cur_conn_set
 
     iauxvar_off = offset
 
@@ -1173,7 +1173,7 @@ contains
     !
     ! !ARGUMENTS
     class(goveqn_richards_ode_pressure_type) :: this
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     !
     ! !LOCAL VARIABLES
     PetscInt                                 :: ghosted_id
@@ -1247,7 +1247,7 @@ contains
     PetscInt                                 :: sum_conn
     PetscReal                                :: temperature
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     character(len=256)                       :: string
 
     ! Update aux vars for boundary cells
@@ -1320,7 +1320,7 @@ contains
     PetscInt                                 :: iconn_active
     PetscInt                                 :: sum_conn
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
 
     return
 
@@ -1488,7 +1488,7 @@ contains
     PetscBool                                :: internal_conn
     PetscInt                                 :: cond_type
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
 
     compute_deriv = PETSC_FALSE
 
@@ -1768,7 +1768,7 @@ contains
     PetscBool                                :: internal_conn
     PetscInt                                 :: cond_type
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
 
     compute_deriv = PETSC_TRUE
 
@@ -2056,7 +2056,7 @@ contains
     PetscBool                                :: cur_cond_used
     PetscInt                                 :: cond_type
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
 
     compute_deriv = PETSC_TRUE
 
@@ -2234,7 +2234,7 @@ contains
     PetscBool                                :: cur_cond_used
     PetscInt                                 :: ivar
     type(condition_type),pointer             :: cur_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
 
     coupling_via_BC  = PETSC_FALSE
     eqns_are_coupled = PETSC_FALSE
@@ -2458,7 +2458,7 @@ contains
     PetscBool                                :: internal_conn
     PetscInt                                 :: cond_type
     type(condition_type),pointer             :: lateral_cond
-    type(connection_set_type), pointer       :: cur_conn_set
+    class(connection_set_type), pointer      :: cur_conn_set
     PetscBool                                :: lateral_cond_found
     PetscErrorCode                           :: ierr
     PetscViewer :: viewer
@@ -2703,8 +2703,8 @@ contains
     PetscReal                 , pointer , intent(in) :: var_value(:)
     !
     ! !LOCAL VARAIABLES:
-    type(connection_set_type) , pointer              :: cur_conn_set
-    type(condition_type)      , pointer              :: cur_cond
+    class(connection_set_type) , pointer             :: cur_conn_set
+    class(condition_type)      , pointer             :: cur_cond
     PetscInt                                         :: iconn
     PetscInt                                         :: nvars
     PetscInt                                         :: sum_conn
@@ -2791,7 +2791,7 @@ contains
     !
     !
     ! !LOCAL VARAIABLES:
-    type(connection_set_type) , pointer              :: cur_conn_set
+    class(connection_set_type) , pointer             :: cur_conn_set
     type(condition_type)      , pointer              :: cur_cond
     PetscInt                                         :: iconn
     PetscInt                                         :: nvars
@@ -2874,7 +2874,7 @@ contains
     !
     !
     ! !LOCAL VARAIABLES:
-    type(connection_set_type) , pointer      :: cur_conn_set
+    class(connection_set_type) , pointer     :: cur_conn_set
 
     ! Interior cells
     cur_conn_set => this%mesh%intrn_conn_set_list%first

--- a/src/mpp/vsfm/MultiPhysicsProbVSFM.F90
+++ b/src/mpp/vsfm/MultiPhysicsProbVSFM.F90
@@ -684,6 +684,21 @@ contains
     call VecCopy(base_soe%solver%soln, base_soe%solver%soln_prev, ierr); CHKERRQ(ierr)
     call VecCopy(base_soe%solver%soln, base_soe%solver%soln_prev_clm, ierr); CHKERRQ(ierr)
 
+    cur_goveq => vsfm_soe%goveqns
+    do
+       if (.not.associated(cur_goveq)) exit
+
+       select type(cur_goveq)
+       class is (goveqn_richards_ode_pressure_type)
+          goveq_richards_pres => cur_goveq
+          do local_id = 1, goveq_richards_pres%mesh%ncells_local
+             goveq_richards_pres%aux_vars_in(local_id)%pressure_prev = &
+                  data_1d(local_id)
+          end do
+       end select
+       cur_goveq => cur_goveq%next
+    enddo
+
     ! Free up memory
     deallocate(dms)
     deallocate(soln_subvecs)

--- a/src/mpp/vsfm/MultiPhysicsProbVSFM.F90
+++ b/src/mpp/vsfm/MultiPhysicsProbVSFM.F90
@@ -290,7 +290,7 @@ contains
     type (rich_ode_pres_auxvar_type), pointer         :: ode_aux_vars_bc(:)
     type (rich_ode_pres_auxvar_type), pointer         :: ode_aux_vars_ss(:)
     type(condition_type),pointer                      :: cur_cond
-    type(connection_set_type), pointer                :: cur_conn_set
+    class(connection_set_type), pointer               :: cur_conn_set
     PetscInt                                          :: ghosted_id
     PetscInt                                          :: sum_conn
     PetscInt                                          :: iconn
@@ -1864,7 +1864,7 @@ contains
     class(goveqn_base_type)                   , pointer             :: cur_goveq
     type (rich_ode_pres_conn_auxvar_type)     , pointer             :: conn_aux_vars(:)
     type(condition_type)                      , pointer             :: cur_cond
-    type(connection_set_type)                 , pointer             :: cur_conn_set
+    class(connection_set_type)                , pointer             :: cur_conn_set
     PetscInt                                                        :: ii
     PetscInt                                                        :: ghosted_id
     PetscInt                                                        :: sum_conn


### PR DESCRIPTION
Add following command line options:

- Ability to prescribe ET, soil BC, and output filename
-  Ability to simulate following mesh configurations:
   -  Mesh for an oak tree with top-soil soil layer as BC,
   -  Mesh for a pine tree with top-soil soil layer as BC,
   -  Mesh for an oak and pine tree with top-soil soil layer as BC,

Fixes #9 