### PR TITLE
Fixes ELM build

### DIFF
--- a/src/mpp/util/mpp_mesh_utils.F90
+++ b/src/mpp/util/mpp_mesh_utils.F90
@@ -1,5 +1,7 @@
 module mpp_mesh_utils
 
+#ifdef USE_PETSC_LIB
+
 #include <petsc/finclude/petsc.h>
 
   use petscsys
@@ -1010,5 +1012,7 @@ contains
     end do
 
   end subroutine Remap1Dto3D
+
+#endif
 
 end module mpp_mesh_utils


### PR DESCRIPTION
Adds `#ifdef` to successfully build the code with PETSc is unavailable.