### PR TITLE
Adds more fix to the PTM

### DIFF
--- a/src/mpp/thermal/GoveqnThermalKSPTemperatureSSWType.F90
+++ b/src/mpp/thermal/GoveqnThermalKSPTemperatureSSWType.F90
@@ -537,8 +537,9 @@ contains
     do icell = 1, this%mesh%ncells_all
        if (aux_vars_in(icell)%is_active) then
           !this%mesh%dz(icell)  = max(1.0d-6, aux_vars_in(icell)%dz)
-          if ( (aux_vars_in(icell)%dz > thin_sfclayer) .and. (aux_vars_in(icell)%frac > thin_sfclayer) ) then
-             this%mesh%dz(icell)  = max(thin_sfclayer, aux_vars_in(icell)%dz/aux_vars_in(icell)%frac )
+          if ( (aux_vars_in(icell)%dz*aux_vars_in(icell)%frac*1.d3 > thin_sfclayer) &
+               .and. (aux_vars_in(icell)%frac > thin_sfclayer) ) then
+             this%mesh%dz(icell)  = max(thin_sfclayer, aux_vars_in(icell)%dz)
           else
              this%mesh%dz(icell) = thin_sfclayer
           endif

--- a/src/mpp/thermal/GoveqnThermalKSPTemperatureSoilType.F90
+++ b/src/mpp/thermal/GoveqnThermalKSPTemperatureSoilType.F90
@@ -626,7 +626,6 @@ contains
 
     call ThermalKSPTempSoilAccum(this, b_p)
     call ThermalKSPTempSoilDivergence(this, b_p)
-    write(*,*)'  Soil: ',b_p(1)
 
     call VecRestoreArrayF90(B, b_p, ierr); CHKERRQ(ierr)
 

--- a/src/mpp/thermal/ThermalKSPTemperatureSSWAuxType.F90
+++ b/src/mpp/thermal/ThermalKSPTemperatureSSWAuxType.F90
@@ -63,8 +63,8 @@ contains
 
        this%therm_cond    = tkwat
        !this%heat_cap_pva  = cpliq*denh2o
-       if ( (dz > thin_sfclayer) .and. (this%frac > thin_sfclayer) ) then
-          this%heat_cap_pva  = max(thin_sfclayer, cpliq*denh2o*dz/this%frac )
+       if ( (dz*this%frac*1.d3 > thin_sfclayer) .and. (this%frac > thin_sfclayer) ) then
+          this%heat_cap_pva  = max(thin_sfclayer, cpliq*denh2o)
        else
           this%heat_cap_pva = thin_sfclayer
        endif


### PR DESCRIPTION
The threshold check implemented in ELM for minimum standing water height
use water height [mm] that is computed without considering the fraction of weighted
grid cell.