### PR TITLE
Rmills/feature use matpreallocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,15 @@ enable_testing()
 
 # Source code itself.
 include_directories("${PROJECT_SOURCE_DIR}")
+
+# RTM: I had to add these to build on OLCF Crusher; not sure why these are needed there but on some other machines
+include_directories("${PROJECT_BINARY_DIR}/src/mpp")
+include_directories("${PROJECT_BINARY_DIR}/src/mpp/auxvar")
+include_directories("${PROJECT_BINARY_DIR}/src/mpp/dtypes")
+include_directories("${PROJECT_BINARY_DIR}/src/mpp/ge")
+include_directories("${PROJECT_BINARY_DIR}/src/mpp/mpp")
+include_directories("${PROJECT_BINARY_DIR}/src/mpp/soe")
+include_directories("${PROJECT_BINARY_DIR}/src/mpp/util")
 add_subdirectory(src)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,9 @@ find_package(PETSc)
 if (NOT PETSC_FOUND)
   message(FATAL_ERROR "PETSc was not found.")
 endif()
-include_directories(${PETSC_INCLUDES})
+#set(PETSC_INCLUDES "${PETSC_INCLUDE_DIRS}")
+#include_directories(${PETSC_INCLUDES})
+include_directories(${PETSC_INCLUDE_DIRS})
 
 # Include PETSc in the rpath.
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${PETSC_DIR}/${PETSC_ARCH}/lib")

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CC         = not-set
 CXX        = not-set
 FC         = not-set
 travis = not-set
+
 # This proxies everything to the builddir cmake.
 
 cputype = $(shell uname -m | sed "s/\\ /_/g")
@@ -21,6 +22,16 @@ BUILDDIR := build/$(systype)-$(cputype)
 CONFIG_FLAGS = -DUNIX=1 -Wno-dev
 
 # Process configuration options.
+
+# Should we skip PETSc tests (generally because we are running on a compile node at a supercomputing center, on which cannot run tests)?
+# Note that we check for both SKIP_PETSC_TESTS or PETSC_SKIP_TESTS,
+# since it is easy for users to confuse the order if only one is considered "correct".
+ifdef SKIP_PETSC_TESTS
+  CONFIG_FLAGS += -DPETSC_SKIP_TESTS:BOOL=ON
+endif
+ifdef PETSC_SKIP_TESTS
+  CONFIG_FLAGS += -DPETSC_SKIP_TESTS:BOOL=ON
+endif
 
 # Travis-CI build
 ifeq ($(travis), not-set)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd MPP
 make CC=$CC CXX=$CXX FC=$FC config
 ```
 
-3. Build MPP
+3. Build MPP (add `SKIP_PETSC_TESTS=yes` if building on a node that cannot run tests)
 ```sh
 make CC=$CC CXX=$CXX FC=$FC install
 ```

--- a/cmake/Modules/FindPETSc.cmake
+++ b/cmake/Modules/FindPETSc.cmake
@@ -1,329 +1,234 @@
 # - Try to find PETSc
 # Once done this will define
 #
-#  PETSC_FOUND        - system has PETSc
-#  PETSC_INCLUDES     - the PETSc include directories
-#  PETSC_LIBRARIES    - Link these to use PETSc
-#  PETSC_COMPILER     - Compiler used by PETSc, helpful to find a compatible MPI
-#  PETSC_DEFINITIONS  - Compiler switches for using PETSc
-#  PETSC_MPIEXEC      - Executable for running MPI programs
-#  PETSC_VERSION      - Version string (MAJOR.MINOR.SUBMINOR)
+#  PETSC_FOUND             - system has PETSc
+#  PETSC_INCLUDE_DIRS      - include directories for PETSc
+#  PETSC_LIBRARY_DIRS      - library directories for PETSc
+#  PETSC_LIBRARIES         - libraries for PETSc
+#  PETSC_STATIC_LIBRARIES  - libraries for PETSc (static linking, undefined if not required)
+#  PETSC_VERSION           - version for PETSc
+#  PETSC_VERSION_MAJOR     - First number in PETSC_VERSION
+#  PETSC_VERSION_MINOR     - Second number in PETSC_VERSION
+#  PETSC_VERSION_SUBMINOR  - Third number in PETSC_VERSION
+#  PETSC_INT_SIZE          - sizeof(PetscInt)
 #
-#  Usage:
-#  find_package(PETSc COMPONENTS CXX)  - required if build --with-clanguage=C++ --with-c-support=0
-#  find_package(PETSc COMPONENTS C)    - standard behavior of checking build using a C compiler
-#  find_package(PETSc)                 - same as above
+#=============================================================================
+# Copyright (C) 2010-2016 Garth N. Wells, Anders Logg and Johannes Ring
+# All rights reserved.
 #
-# Setting these changes the behavior of the search
-#  PETSC_DIR - directory in which PETSc resides
-#  PETSC_ARCH - build architecture
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
 #
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
 #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
 
-set(PETSC_VALID_COMPONENTS
-  C
-  CXX)
+# Provide option that allows the PETSc tests to be skipped, setting default to OFF
+option(PETSC_SKIP_TESTS "PETSC_SKIP_TESTS" OFF)
 
-if(NOT PETSc_FIND_COMPONENTS)
-  set(PETSC_LANGUAGE_BINDINGS "C")
-else()
-  # Right now, this is designed for compatability with the --with-clanguage option, so
-  # only allow one item in the components list.
-  list(LENGTH ${PETSc_FIND_COMPONENTS} components_length)
-  if(${components_length} GREATER 1)
-    message(FATAL_ERROR "Only one component for PETSc is allowed to be specified")
-  endif()
-  # This is a stub for allowing multiple components should that time ever come. Perhaps
-  # to also test Fortran bindings?
-  foreach(component ${PETSc_FIND_COMPONENTS})
-    list(FIND PETSC_VALID_COMPONENTS ${component} component_location)
-    if(${component_location} EQUAL -1)
-      message(FATAL_ERROR "\"${component}\" is not a valid PETSc component.")
-    else()
-      list(APPEND PETSC_LANGUAGE_BINDINGS ${component})
-    endif()
-  endforeach()
+# Outline:
+# 1. Get flags from PETSc-generated pkg-config file
+# 2. Test compile and run program using shared library linking
+# 3. If shared library linking fails, test with static library linking
+
+# Load pkg-config module (provided by CMake)
+find_package(PkgConfig REQUIRED)
+
+# Find PETSc pkg-config file. Note: craypetsc_real is on Cray systems
+set(ENV{PKG_CONFIG_PATH} "$ENV{CRAY_PETSC_PREFIX_DIR}/lib/pkgconfig:$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/lib/pkgconfig:$ENV{PETSC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+pkg_search_module(PETSC craypetsc_real PETSc)
+
+# Extract major, minor, etc from version string
+if (PETSC_VERSION)
+  string(REPLACE "." ";" VERSION_LIST ${PETSC_VERSION})
+  list(GET VERSION_LIST 0 PETSC_VERSION_MAJOR)
+  list(GET VERSION_LIST 1 PETSC_VERSION_MINOR)
+  list(GET VERSION_LIST 2 PETSC_VERSION_SUBMINOR)
 endif()
 
-function (petsc_get_version)
-  if (EXISTS "${PETSC_DIR}/include/petscversion.h")
-    file (STRINGS "${PETSC_DIR}/include/petscversion.h" vstrings REGEX "#define PETSC_VERSION_(RELEASE|MAJOR|MINOR|SUBMINOR|PATCH) ")
-    foreach (line ${vstrings})
-      string (REGEX REPLACE " +" ";" fields ${line}) # break line into three fields (the first is always "#define")
-      list (GET fields 1 var)
-      list (GET fields 2 val)
-      set (${var} ${val} PARENT_SCOPE)
-      set (${var} ${val})         # Also in local scope so we have access below
-    endforeach ()
-    if (PETSC_VERSION_RELEASE)
-      set (PETSC_VERSION "${PETSC_VERSION_MAJOR}.${PETSC_VERSION_MINOR}.${PETSC_VERSION_SUBMINOR}p${PETSC_VERSION_PATCH}" PARENT_SCOPE)
-    else ()
-      # make dev version compare higher than any patch level of a released version
-      set (PETSC_VERSION "${PETSC_VERSION_MAJOR}.${PETSC_VERSION_MINOR}.${PETSC_VERSION_SUBMINOR}.99" PARENT_SCOPE)
-    endif ()
-  else ()
-    message (SEND_ERROR "PETSC_DIR can not be used, ${PETSC_DIR}/include/petscversion.h does not exist")
-  endif ()
-endfunction ()
+# Configure PETSc IMPORT (this involves creating an 'imported' target
+# and attaching 'properties')
+if (PETSC_FOUND AND NOT TARGET PETSC::petsc)
+  add_library(PETSC::petsc INTERFACE IMPORTED)
 
-find_path (PETSC_DIR include/petsc.h
-  HINTS ENV PETSC_DIR
-  PATHS
-  # Debian paths
-  /usr/lib/petscdir/3.5.1 /usr/lib/petscdir/3.5
-  /usr/lib/petscdir/3.4.2 /usr/lib/petscdir/3.4
-  /usr/lib/petscdir/3.3 /usr/lib/petscdir/3.2 /usr/lib/petscdir/3.1
-  /usr/lib/petscdir/3.0.0 /usr/lib/petscdir/2.3.3 /usr/lib/petscdir/2.3.2
-  # MacPorts path
-  /opt/local/lib/petsc
-  $ENV{HOME}/petsc
-  DOC "PETSc Directory")
+  # Add include paths
+  set_property(TARGET PETSC::petsc PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${PETSC_INCLUDE_DIRS})
 
-find_program (MAKE_EXECUTABLE NAMES make gmake)
+  # Add libraries
+  unset(_libs)
+  foreach (lib ${PETSC_LIBRARIES})
+    find_library(LIB_${lib} NAMES ${lib} PATHS ${PETSC_LIBRARY_DIRS} NO_DEFAULT_PATH)
+    list(APPEND _libs ${LIB_${lib}})
+  endforeach()
+  set_property(TARGET PETSC::petsc PROPERTY INTERFACE_LINK_LIBRARIES "${_libs}")
+endif()
 
-if (PETSC_DIR AND NOT PETSC_ARCH)
-  set (_petsc_arches
-    $ENV{PETSC_ARCH}                   # If set, use environment variable first
-    linux-gnu-c-debug linux-gnu-c-opt  # Debian defaults
-    x86_64-unknown-linux-gnu i386-unknown-linux-gnu)
-  set (petscconf "NOTFOUND" CACHE FILEPATH "Cleared" FORCE)
-  foreach (arch ${_petsc_arches})
-    if (NOT PETSC_ARCH)
-      find_path (petscconf petscconf.h
-        HINTS ${PETSC_DIR}
-        PATH_SUFFIXES ${arch}/include bmake/${arch}
-        NO_DEFAULT_PATH)
-      if (petscconf)
-        set (PETSC_ARCH "${arch}" CACHE STRING "PETSc build architecture")
-      endif (petscconf)
-    endif (NOT PETSC_ARCH)
-  endforeach (arch)
-  set (petscconf "NOTFOUND" CACHE INTERNAL "Scratch variable" FORCE)
-endif (PETSC_DIR AND NOT PETSC_ARCH)
+# Configure PETSc 'static' IMPORT (this involves creating an
+# 'imported' target and attaching 'properties')
+if (PETSC_FOUND AND NOT TARGET PETSC::petsc_static)
+  add_library(PETSC::petsc_static INTERFACE IMPORTED)
 
-set (petsc_slaves LIBRARIES_SYS LIBRARIES_VEC LIBRARIES_MAT LIBRARIES_DM LIBRARIES_KSP LIBRARIES_SNES LIBRARIES_TS
-  INCLUDE_DIR INCLUDE_CONF)
-include (FindPackageMultipass)
-find_package_multipass (PETSc petsc_config_current
-  STATES DIR ARCH
-  DEPENDENTS INCLUDES LIBRARIES COMPILER MPIEXEC ${petsc_slaves})
+  # Add libraries (static)
+  unset(_libs)
+  foreach (lib ${PETSC_STATIC_LIBRARIES})
+    find_library(LIB_${lib} ${lib} HINTS ${PETSC_STATIC_LIBRARY_DIRS})
+    list(APPEND _libs ${LIB_${lib}})
+  endforeach()
+  set_property(TARGET PETSC::petsc_static PROPERTY INTERFACE_LINK_LIBRARIES "${_libs}")
+endif()
 
-# Determine whether the PETSc layout is old-style (through 2.3.3) or
-# new-style (>= 3.0.0)
-if (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables") # > 3.5
-  set (petsc_conf_rules "${PETSC_DIR}/lib/petsc/conf/rules")
-  set (petsc_conf_variables "${PETSC_DIR}/lib/petsc/conf/variables")
-elseif (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h")   # > 2.3.3
-  set (petsc_conf_rules "${PETSC_DIR}/conf/rules")
-  set (petsc_conf_variables "${PETSC_DIR}/conf/variables")
-elseif (EXISTS "${PETSC_DIR}/bmake/${PETSC_ARCH}/petscconf.h") # <= 2.3.3
-  set (petsc_conf_rules "${PETSC_DIR}/bmake/common/rules")
-  set (petsc_conf_variables "${PETSC_DIR}/bmake/common/variables")
-elseif (PETSC_DIR)
-  message (SEND_ERROR "The pair PETSC_DIR=${PETSC_DIR} PETSC_ARCH=${PETSC_ARCH} do not specify a valid PETSc installation")
-endif ()
+# Attempt to build and run PETSc test program
+if (PETSC_SKIP_TESTS)
 
-if (petsc_conf_rules AND petsc_conf_variables AND NOT petsc_config_current)
-  petsc_get_version()
+  # Assume PETSc works
+  set(PETSC_TEST_RUNS TRUE)
+  message( "PETSc tests will be skipped at user's request" )
 
-  # Put variables into environment since they are needed to get
-  # configuration (petscvariables) in the PETSc makefile
-  set (ENV{PETSC_DIR} "${PETSC_DIR}")
-  set (ENV{PETSC_ARCH} "${PETSC_ARCH}")
+elseif (PETSC_FOUND)
 
-  # A temporary makefile to probe the PETSc configuration
-  set (petsc_config_makefile "${PROJECT_BINARY_DIR}/Makefile.petsc")
-  file (WRITE "${petsc_config_makefile}"
-"## This file was autogenerated by FindPETSc.cmake
-# PETSC_DIR  = ${PETSC_DIR}
-# PETSC_ARCH = ${PETSC_ARCH}
-include ${petsc_conf_rules}
-include ${petsc_conf_variables}
-show :
-\t-@echo -n \${\${VARIABLE}}
-")
-
-  macro (PETSC_GET_VARIABLE name var)
-    set (${var} "NOTFOUND" CACHE INTERNAL "Cleared" FORCE)
-    execute_process (COMMAND ${MAKE_EXECUTABLE} --no-print-directory -f ${petsc_config_makefile} show VARIABLE=${name}
-      OUTPUT_VARIABLE ${var}
-      RESULT_VARIABLE petsc_return)
-  endmacro (PETSC_GET_VARIABLE)
-  petsc_get_variable (PETSC_LIB_DIR            petsc_lib_dir)
-  petsc_get_variable (PETSC_EXTERNAL_LIB_BASIC petsc_libs_external)
-  petsc_get_variable (PETSC_CCPPFLAGS          petsc_cpp_line)
-  petsc_get_variable (PETSC_INCLUDE            petsc_include)
-  petsc_get_variable (PCC                      petsc_cc)
-  petsc_get_variable (PCC_FLAGS                petsc_cc_flags)
-  petsc_get_variable (MPIEXEC                  petsc_mpiexec)
-  # We are done with the temporary Makefile, calling PETSC_GET_VARIABLE after this point is invalid!
-  file (REMOVE ${petsc_config_makefile})
-
-  include (ResolveCompilerPaths)
-  # Extract include paths and libraries from compile command line
-  resolve_includes (petsc_includes_all "${petsc_cpp_line}")
-
-  #on windows we need to make sure we're linking against the right
-  #runtime library
-  if (WIN32)
-    if (petsc_cc_flags MATCHES "-MT")
-      set(using_md False)
-      foreach(flag_var
-          CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-          CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
-          CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-          CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        if(${flag_var} MATCHES "/MD")
-          set(using_md True)
-        endif(${flag_var} MATCHES "/MD")
-      endforeach(flag_var)
-      if(${using_md} MATCHES "True")
-        message(WARNING "PETSc was built with /MT, but /MD is currently set.
- See http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F")
-      endif(${using_md} MATCHES "True")
-    endif (petsc_cc_flags MATCHES "-MT")
-  endif (WIN32)
-
-  include (CorrectWindowsPaths)
-  convert_cygwin_path(petsc_lib_dir)
-  message (STATUS "petsc_lib_dir ${petsc_lib_dir}")
-
-  macro (PETSC_FIND_LIBRARY suffix name)
-    set (PETSC_LIBRARY_${suffix} "NOTFOUND" CACHE INTERNAL "Cleared" FORCE) # Clear any stale value, if we got here, we need to find it again
-    if (WIN32)
-      set (libname lib${name}) #windows expects "libfoo", linux expects "foo"
-    else (WIN32)
-      set (libname ${name})
-    endif (WIN32)
-    find_library (PETSC_LIBRARY_${suffix} NAMES ${libname} HINTS ${petsc_lib_dir} NO_DEFAULT_PATH)
-    set (PETSC_LIBRARIES_${suffix} "${PETSC_LIBRARY_${suffix}}")
-    mark_as_advanced (PETSC_LIBRARY_${suffix})
-  endmacro (PETSC_FIND_LIBRARY suffix name)
-
-  # Look for petscvec first, if it doesn't exist, we must be using single-library
-  petsc_find_library (VEC petscvec)
-  if (PETSC_LIBRARY_VEC)
-    petsc_find_library (SYS  "petscsys;petsc") # libpetscsys is called libpetsc prior to 3.1 (when single-library was introduced)
-    petsc_find_library (MAT  petscmat)
-    petsc_find_library (DM   petscdm)
-    petsc_find_library (KSP  petscksp)
-    petsc_find_library (SNES petscsnes)
-    petsc_find_library (TS   petscts)
-    macro (PETSC_JOIN libs deps)
-      list (APPEND PETSC_LIBRARIES_${libs} ${PETSC_LIBRARIES_${deps}})
-    endmacro (PETSC_JOIN libs deps)
-    petsc_join (VEC  SYS)
-    petsc_join (MAT  VEC)
-    petsc_join (DM   MAT)
-    petsc_join (KSP  DM)
-    petsc_join (SNES KSP)
-    petsc_join (TS   SNES)
-    petsc_join (ALL  TS)
-  else ()
-    set (PETSC_LIBRARY_VEC "NOTFOUND" CACHE INTERNAL "Cleared" FORCE) # There is no libpetscvec
-    petsc_find_library (SINGLE petsc)
-    foreach (pkg SYS VEC MAT DM KSP SNES TS ALL)
-      set (PETSC_LIBRARIES_${pkg} "${PETSC_LIBRARY_SINGLE}")
-    endforeach ()
-  endif ()
-  if (PETSC_LIBRARY_TS)
-    message (STATUS "Recognized PETSc install with separate libraries for each package")
-  else ()
-    message (STATUS "Recognized PETSc install with single library for all packages")
-  endif ()
-
-  include(Check${PETSC_LANGUAGE_BINDINGS}SourceRuns)
-  macro (PETSC_TEST_RUNS includes libraries runs)
-    if(${PETSC_LANGUAGE_BINDINGS} STREQUAL "C")
-      set(_PETSC_ERR_FUNC "CHKERRQ(ierr)")
-    elseif(${PETSC_LANGUAGE_BINDINGS} STREQUAL "CXX")
-      set(_PETSC_ERR_FUNC "CHKERRXX(ierr)")
-    endif()
-    if (PETSC_VERSION VERSION_GREATER 3.1)
-      set (_PETSC_TSDestroy "TSDestroy(&ts)")
-    else ()
-      set (_PETSC_TSDestroy "TSDestroy(ts)")
-    endif ()
-
-    set(_PETSC_TEST_SOURCE "
-static const char help[] = \"PETSc test program.\";
-#include <petscts.h>
-int main(int argc,char *argv[]) {
+  # Create PETSc test program
+  set(PETSC_TEST_LIB_CPP
+    "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/petsc_test_lib.cpp")
+  file(WRITE ${PETSC_TEST_LIB_CPP} "
+#include \"petscts.h\"
+#include \"petsc.h\"
+int main()
+{
   PetscErrorCode ierr;
   TS ts;
-
-  ierr = PetscInitialize(&argc,&argv,0,help);${_PETSC_ERR_FUNC};
-  ierr = TSCreate(PETSC_COMM_WORLD,&ts);${_PETSC_ERR_FUNC};
-  ierr = TSSetFromOptions(ts);${_PETSC_ERR_FUNC};
-  ierr = ${_PETSC_TSDestroy};${_PETSC_ERR_FUNC};
-  ierr = PetscFinalize();${_PETSC_ERR_FUNC};
+  int argc = 0;
+  char** argv = NULL;
+  ierr = PetscInitialize(&argc, &argv, PETSC_NULL, PETSC_NULL);CHKERRQ(ierr);
+  ierr = TSCreate(PETSC_COMM_WORLD,&ts);CHKERRQ(ierr);
+  ierr = TSSetFromOptions(ts);CHKERRQ(ierr);
+  ierr = TSDestroy(&ts);CHKERRQ(ierr);
+  ierr = PetscFinalize();CHKERRQ(ierr);
   return 0;
 }
 ")
-    multipass_source_runs ("${includes}" "${libraries}" "${_PETSC_TEST_SOURCE}" ${runs} "${PETSC_LANGUAGE_BINDINGS}")
-    if (${${runs}})
-      set (PETSC_EXECUTABLE_RUNS "YES" CACHE BOOL
-        "Can the system successfully run a PETSc executable?  This variable can be manually set to \"YES\" to force CMake to accept a given PETSc configuration, but this will almost always result in a broken build.  If you change PETSC_DIR, PETSC_ARCH, or PETSC_CURRENT you would have to reset this variable." FORCE)
-    endif (${${runs}})
-  endmacro (PETSC_TEST_RUNS)
 
+  # Add MPI variables if MPI has been found
+  if (MPI_C_FOUND)
+    set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${MPI_C_INCLUDE_PATH})
+    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${MPI_C_LIBRARIES})
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${MPI_C_COMPILE_FLAGS}")
+  endif()
 
-  find_path (PETSC_INCLUDE_DIR petscts.h HINTS "${PETSC_DIR}" PATH_SUFFIXES include NO_DEFAULT_PATH)
-  find_path (PETSC_INCLUDE_CONF petscconf.h HINTS "${PETSC_DIR}" PATH_SUFFIXES "${PETSC_ARCH}/include" "bmake/${PETSC_ARCH}" NO_DEFAULT_PATH)
-  mark_as_advanced (PETSC_INCLUDE_DIR PETSC_INCLUDE_CONF)
-  set (petsc_includes_minimal ${PETSC_INCLUDE_CONF} ${PETSC_INCLUDE_DIR})
+  # Try to run test program (shared linking)
+  try_run(
+    PETSC_TEST_LIB_EXITCODE
+    PETSC_TEST_LIB_COMPILED
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${PETSC_TEST_LIB_CPP}
+    CMAKE_FLAGS
+    "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}"
+    LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} PETSC::petsc
+    COMPILE_OUTPUT_VARIABLE PETSC_TEST_LIB_COMPILE_OUTPUT
+    RUN_OUTPUT_VARIABLE PETSC_TEST_LIB_OUTPUT)
 
-  petsc_test_runs ("${petsc_includes_minimal}" "${PETSC_LIBRARIES_TS}" petsc_works_minimal)
-  if (petsc_works_minimal)
-    message (STATUS "Minimal PETSc includes and libraries work.  This probably means we are building with shared libs.")
-    set (petsc_includes_needed "${petsc_includes_minimal}")
-  else (petsc_works_minimal)     # Minimal includes fail, see if just adding full includes fixes it
-    petsc_test_runs ("${petsc_includes_all}" "${PETSC_LIBRARIES_TS}" petsc_works_allincludes)
-    if (petsc_works_allincludes) # It does, we just need all the includes (
-      message (STATUS "PETSc requires extra include paths, but links correctly with only interface libraries.  This is an unexpected configuration (but it seems to work fine).")
-      set (petsc_includes_needed ${petsc_includes_all})
-    else (petsc_works_allincludes) # We are going to need to link the external libs explicitly
-      resolve_libraries (petsc_libraries_external "${petsc_libs_external}")
-      foreach (pkg SYS VEC MAT DM KSP SNES TS ALL)
-        list (APPEND PETSC_LIBRARIES_${pkg}  ${petsc_libraries_external})
-      endforeach (pkg)
-      petsc_test_runs ("${petsc_includes_minimal}" "${PETSC_LIBRARIES_TS}" petsc_works_alllibraries)
-      if (petsc_works_alllibraries)
-         message (STATUS "PETSc only need minimal includes, but requires explicit linking to all dependencies.  This is expected when PETSc is built with static libraries.")
-        set (petsc_includes_needed ${petsc_includes_minimal})
-      else (petsc_works_alllibraries)
-        # It looks like we really need everything, should have listened to Matt
-        set (petsc_includes_needed ${petsc_includes_all})
-        petsc_test_runs ("${petsc_includes_all}" "${PETSC_LIBRARIES_TS}" petsc_works_all)
-        if (petsc_works_all) # We fail anyways
-          message (STATUS "PETSc requires extra include paths and explicit linking to all dependencies.  This probably means you have static libraries and something unexpected in PETSc headers.")
-        else (petsc_works_all) # We fail anyways
-          message (STATUS "PETSc could not be used, maybe the install is broken.")
-        endif (petsc_works_all)
-      endif (petsc_works_alllibraries)
-    endif (petsc_works_allincludes)
-  endif (petsc_works_minimal)
+  # Check program output
+  if (PETSC_TEST_LIB_COMPILED AND PETSC_TEST_LIB_EXITCODE EQUAL 0)
 
-  # We do an out-of-source build so __FILE__ will be an absolute path, hence __INSDIR__ is superfluous
-  if (${PETSC_VERSION} VERSION_LESS 3.1)
-    set (PETSC_DEFINITIONS "-D__SDIR__=\"\"" CACHE STRING "PETSc definitions" FORCE)
-  else ()
-    set (PETSC_DEFINITIONS "-D__INSDIR__=" CACHE STRING "PETSc definitions" FORCE)
-  endif ()
-  # Sometimes this can be used to assist FindMPI.cmake
-  set (PETSC_MPIEXEC ${petsc_mpiexec} CACHE FILEPATH "Executable for running PETSc MPI programs" FORCE)
-  set (PETSC_INCLUDES ${petsc_includes_needed} CACHE STRING "PETSc include path" FORCE)
-  set (PETSC_LIBRARIES ${PETSC_LIBRARIES_ALL} CACHE STRING "PETSc libraries" FORCE)
-  set (PETSC_COMPILER ${petsc_cc} CACHE FILEPATH "PETSc compiler" FORCE)
-  # Note that we have forced values for all these choices.  If you
-  # change these, you are telling the system to trust you that they
-  # work.  It is likely that you will end up with a broken build.
-  mark_as_advanced (PETSC_INCLUDES PETSC_LIBRARIES PETSC_COMPILER PETSC_DEFINITIONS PETSC_MPIEXEC PETSC_EXECUTABLE_RUNS)
-endif ()
+    message(STATUS "Test PETSC_TEST_RUNS with shared library linking - Success")
+    set(PETSC_TEST_RUNS TRUE)
 
-include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (PETSc
-  "PETSc could not be found.  Be sure to set PETSC_DIR and PETSC_ARCH."
-  PETSC_INCLUDES PETSC_LIBRARIES PETSC_EXECUTABLE_RUNS)
+    # Static libraries not required, so unset
+    set_property(TARGET PETSC::petsc_static PROPERTY INTERFACE_LINK_LIBRARIES)
+
+  else()
+
+    message(STATUS "Test PETSC_TEST_RUNS with shared library linking - Failed")
+
+    file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+      "Failed to run PETSc test with shared library linking:\n"
+      "CMAKE_REQUIRED_INCLUDES: ${CMAKE_REQUIRED_INCLUDES}\n"
+      "CMAKE_REQUIRED_LIBRARIES: ${CMAKE_REQUIRED_LIBRARIES}\n"
+      "CMAKE_REQUIRED_FLAGS: ${CMAKE_REQUIRED_FLAGS}\n"
+      "PETSC_TEST_LIB_EXITCODE: ${PETSC_TEST_LIB_EXITCODE}\n"
+      "PETSC_TEST_LIB_COMPILED: ${PETSC_TEST_LIB_COMPILED}\n"
+      "PETSC_TEST_LIB_COMPILE_OUTPUT: ${PETSC_TEST_LIB_COMPILE_OUTPUT}\n"
+      "PETSC_TEST_LIB_OUTPUT: ${PETSC_TEST_LIB_OUTPUT}\n\n")
+
+    # Add MPI variables if MPI has been found
+    if (MPI_C_FOUND)
+      set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${MPI_C_INCLUDE_PATH})
+      set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${MPI_C_LIBRARIES})
+      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${MPI_C_COMPILE_FLAGS}")
+    endif()
+
+    # Try to run test program (static linking)
+    try_run(
+      PETSC_TEST_LIB_EXITCODE
+      PETSC_TEST_LIB_COMPILED
+      ${CMAKE_CURRENT_BINARY_DIR}
+      ${PETSC_TEST_LIB_CPP}
+      CMAKE_FLAGS
+      "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}"
+      LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} PETSC::petsc PETSC::petsc_static
+      COMPILE_OUTPUT_VARIABLE PETSC_TEST_LIB_COMPILE_OUTPUT
+      RUN_OUTPUT_VARIABLE PETSC_TEST_LIB_OUTPUT)
+
+    if (PETSC_TEST_LIB_COMPILED AND PETSC_TEST_LIB_EXITCODE EQUAL 0)
+      message(STATUS "Test PETSC_TEST_RUNS static linking - Success")
+      set(PETSC_TEST_RUNS TRUE)
+    else()
+      message(STATUS "Test PETSC_TEST_RUNS static linking - Failed")
+
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Failed to run PETSc test with static library linking:\n"
+        "CMAKE_REQUIRED_INCLUDES: ${CMAKE_REQUIRED_INCLUDES}\n"
+        "CMAKE_REQUIRED_LIBRARIES: ${CMAKE_REQUIRED_LIBRARIES}\n"
+        "CMAKE_REQUIRED_FLAGS: ${CMAKE_REQUIRED_FLAGS}\n"
+        "PETSC_TEST_LIB_EXITCODE: ${PETSC_TEST_LIB_EXITCODE}\n"
+        "PETSC_TEST_LIB_COMPILED: ${PETSC_TEST_LIB_COMPILED}\n"
+        "PETSC_TEST_LIB_COMPILE_OUTPUT: ${PETSC_TEST_LIB_COMPILE_OUTPUT}\n"
+        "PETSC_TEST_LIB_OUTPUT: ${PETSC_TEST_LIB_OUTPUT}\n\n")
+
+      set(PETSC_TEST_RUNS FALSE)
+    endif()
+
+  endif()
+endif()
+
+# Check sizeof(PetscInt)
+if (PETSC_INCLUDE_DIRS)
+  include(CheckTypeSize)
+  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${PETSC_INCLUDE_DIRS})
+  set(CMAKE_EXTRA_INCLUDE_FILES petscsys.h)
+  check_type_size("PetscInt" PETSC_INT_SIZE)
+
+  unset(CMAKE_EXTRA_INCLUDE_FILES)
+  unset(CMAKE_REQUIRED_INCLUDES)
+endif()
+
+# Standard package handling
+include(FindPackageHandleStandardArgs)
+if (PETSC_FOUND)
+  find_package_handle_standard_args(PETSc
+    REQUIRED_VARS PETSC_FOUND PETSC_TEST_RUNS VERSION_VAR PETSC_VERSION
+    FAIL_MESSAGE "PETSc could not be configured.")
+else()
+  find_package_handle_standard_args(PETSc
+    REQUIRED_VARS PETSC_FOUND
+    FAIL_MESSAGE "PETSc could not be found. Be sure to set PETSC_DIR.")
+endif()
+

--- a/src/driver/dummy/CMakeLists.txt
+++ b/src/driver/dummy/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 #set(MPP_LIBRARIES mpp_driver;${MPP_LIBRARIES})
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/CMakeLists.txt
+++ b/src/driver/standalone/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/longwave)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/shortwave)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/leafbndlyr/CMakeLists.txt
+++ b/src/driver/standalone/leafbndlyr/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/longwave/CMakeLists.txt
+++ b/src/driver/standalone/longwave/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/mlc/CMakeLists.txt
+++ b/src/driver/standalone/mlc/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/mlc/mlc_parameters.F90
+++ b/src/driver/standalone/mlc/mlc_parameters.F90
@@ -272,7 +272,7 @@ contains
           end if
 
           zrel = min(z_int/hc,1.d0)
-          beta_pdf = (zrel**(pbeta-1) * (1.d0 - zrel)**(qbeta-1))/exp(lgamma(pbeta) + lgamma(qbeta) - lgamma(pbeta+qbeta));
+          beta_pdf = (zrel**(pbeta-1) * (1.d0 - zrel)**(qbeta-1))/exp(log_gamma(pbeta) + log_gamma(qbeta) - log_gamma(pbeta+qbeta));
           pad = (pai / hc) * beta_pdf
 
           dpai(k) = dpai(k) + pad * dz_int

--- a/src/driver/standalone/photosynthesis/CMakeLists.txt
+++ b/src/driver/standalone/photosynthesis/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/shortwave/CMakeLists.txt
+++ b/src/driver/standalone/shortwave/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/thermal-e/CMakeLists.txt
+++ b/src/driver/standalone/thermal-e/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/thermal-e/heat_transport_1D.F90
+++ b/src/driver/standalone/thermal-e/heat_transport_1D.F90
@@ -75,9 +75,9 @@ program heat_transport_1D
         string = 'initial_soln_' // trim(output_suffix) // '.bin'
      endif
 
-     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
-     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRQ(ierr)
-     call PetscViewerDestroy(viewer,ierr);CHKERRQ(ierr)
+     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRA(ierr)
+     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRA(ierr)
+     call PetscViewerDestroy(viewer,ierr);CHKERRA(ierr)
   endif
 
   do istep = 1, nstep
@@ -86,7 +86,7 @@ program heat_transport_1D
 
      ! Run the model
      call thermal_enthalpy_mpp%soe%StepDT(dtime, istep, &
-          converged, converged_reason, ierr); CHKERRQ(ierr)
+          converged, converged_reason, ierr); CHKERRA(ierr)
   enddo
 
   if (save_final_soln) then
@@ -95,9 +95,9 @@ program heat_transport_1D
      else
         string = 'final_soln_' // trim(output_suffix) // '.bin'
      endif
-     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
-     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRQ(ierr)
-     call PetscViewerDestroy(viewer,ierr);CHKERRQ(ierr)
+     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRA(ierr)
+     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRA(ierr)
+     call PetscViewerDestroy(viewer,ierr);CHKERRA(ierr)
   endif
 
 end program heat_transport_1D

--- a/src/driver/standalone/thermal-e/heat_transport_1D_with_advection.F90
+++ b/src/driver/standalone/thermal-e/heat_transport_1D_with_advection.F90
@@ -72,9 +72,9 @@ program heat_transport_1D_with_advection
         string = 'initial_soln_' // trim(output_suffix) // '.bin'
      endif
 
-     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
-     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRQ(ierr)
-     call PetscViewerDestroy(viewer,ierr);CHKERRQ(ierr)
+     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRA(ierr)
+     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRA(ierr)
+     call PetscViewerDestroy(viewer,ierr);CHKERRA(ierr)
   endif
 
   do istep = 1, nstep
@@ -83,7 +83,7 @@ program heat_transport_1D_with_advection
 
      ! Run the model
      call thermal_enthalpy_mpp%soe%StepDT(dtime, istep, &
-          converged, converged_reason, ierr); CHKERRQ(ierr)
+          converged, converged_reason, ierr); CHKERRA(ierr)
   enddo
 
   if (save_final_soln) then
@@ -92,9 +92,9 @@ program heat_transport_1D_with_advection
      else
         string = 'final_soln_' // trim(output_suffix) // '.bin'
      endif
-     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRQ(ierr)
-     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRQ(ierr)
-     call PetscViewerDestroy(viewer,ierr);CHKERRQ(ierr)
+     call PetscViewerBinaryOpen(PETSC_COMM_SELF,trim(string),FILE_MODE_WRITE,viewer,ierr);CHKERRA(ierr)
+     call VecView(thermal_enthalpy_mpp%soe%solver%soln,viewer,ierr);CHKERRA(ierr)
+     call PetscViewerDestroy(viewer,ierr);CHKERRA(ierr)
   endif
 
 end program heat_transport_1D_with_advection

--- a/src/driver/standalone/thermal/CMakeLists.txt
+++ b/src/driver/standalone/thermal/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/driver/standalone/vsfm/CMakeLists.txt
+++ b/src/driver/standalone/vsfm/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 include_directories(${CMAKE_BINARY_DIR}/src/driver/standalone/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})

--- a/src/mpp/dtypes/ConditionType.F90
+++ b/src/mpp/dtypes/ConditionType.F90
@@ -35,7 +35,7 @@ module ConditionType
      PetscBool                 , pointer :: is_the_other_GE_coupled_via_int_auxvars(:) ! TRUE : The i-th coupling governing equation is coupled via internal auxvars
                                                                                        ! FALSE: The i-th coupling governing equation is coupled via boundary auxvars
 
-     type(connection_set_type) , pointer :: conn_set                                   ! Applicable to BC condition type
+     class(connection_set_type) , pointer :: conn_set                                   ! Applicable to BC condition type
      type(condition_type)      , pointer :: next                                       ! Pointer to next condition
 
      contains

--- a/src/mpp/dtypes/GoverningEquationBaseType.F90
+++ b/src/mpp/dtypes/GoverningEquationBaseType.F90
@@ -556,7 +556,7 @@ contains
     character(len =*)                           :: unit
     PetscInt                                    :: cond_type
     PetscInt, optional                          :: region_type
-    type(connection_set_type),pointer, optional :: conn_set
+    class(connection_set_type),pointer, optional :: conn_set
     !
     type(condition_type), pointer :: cond
 
@@ -614,7 +614,7 @@ contains
     PetscInt                  , intent(in), pointer              :: itype_of_other_goveqs(:)
     PetscBool                 , intent(in), pointer, optional    :: icoupling_of_other_goveqns(:)
     PetscInt                  , intent(in), optional             :: region_type
-    type(connection_set_type) , intent(inout), pointer, optional :: conn_set
+    class(connection_set_type) , intent(inout), pointer, optional :: conn_set
     !
     type(condition_type)      , pointer                          :: cond
 
@@ -665,7 +665,7 @@ contains
     character(len =*)                           :: unit
     PetscInt                                    :: cond_type
     PetscInt, optional                          :: region_type
-    type(connection_set_type),pointer, optional :: conn_set
+    class(connection_set_type),pointer, optional :: conn_set
 
     cond%name         = trim(name)
     cond%units        = trim(unit)

--- a/src/mpp/dtypes/GoverningEquationBaseType.F90
+++ b/src/mpp/dtypes/GoverningEquationBaseType.F90
@@ -745,7 +745,7 @@ contains
        enddo
 
        if (icond > num_conditions) then
-          write(iulog,*),'Could not find the BC whose ' // &
+          write(iulog,*) 'Could not find the BC whose ' // &
                'connection set needs to be updated.'
           call endrun(msg=errMsg(__FILE__, __LINE__))
        endif
@@ -764,7 +764,7 @@ contains
        enddo
 
        if (icond > num_conditions) then
-          write(iulog,*),'Could not find the SS whose ' // &
+          write(iulog,*) 'Could not find the SS whose ' // &
                'connection set needs to be updated.'
           call endrun(msg=errMsg(__FILE__, __LINE__))
        endif

--- a/src/mpp/dtypes/MeshType.F90
+++ b/src/mpp/dtypes/MeshType.F90
@@ -667,7 +667,7 @@ contains
     ! !ARGUMENTS
     type(mesh_type)                   :: mesh
     PetscInt                          :: region_itype
-    type(connection_set_type),pointer :: conn_set
+    class(connection_set_type),pointer :: conn_set
     PetscInt, intent(out)             :: ncells_local
     PetscInt,optional                 :: soil_top_cell_offset
     PetscBool, optional               :: use_clm_dist_to_interface

--- a/src/mpp/soe/SystemOfEquationsBaseType.F90
+++ b/src/mpp/soe/SystemOfEquationsBaseType.F90
@@ -609,6 +609,7 @@ contains
     call MatSetLocalToGlobalMapping(preallocator, rmapping, cmapping, ierr); CHKERRQ(ierr)
     call soe%ComputeOperators(soe%solver%ksp, preallocator, preallocator, ierr);
     call MatPreallocatorPreallocate(preallocator, PETSC_TRUE, soe%solver%Amat, ierr); CHKERRQ(ierr)
+    call MatDestroy(preallocator, ierr); CHKERRQ(ierr)
 
     ! Compute the 'A' matrix
     call soe%ComputeOperators(soe%solver%ksp, soe%solver%Amat, soe%solver%Amat, ierr);

--- a/src/mpp/soe/SystemOfEquationsBaseType.F90
+++ b/src/mpp/soe/SystemOfEquationsBaseType.F90
@@ -1182,7 +1182,7 @@ contains
     PetscInt                  , pointer, intent(in) :: id_of_other_goveqs(:)
     PetscBool                 , pointer, optional   :: icoupling_of_other_goveqns(:)
     PetscInt                  , intent(in), optional:: region_type
-    type(connection_set_type) , pointer, optional   :: conn_set
+    class(connection_set_type) , pointer, optional   :: conn_set
     !
     ! !LOCAL VARIABLES
     class(goveqn_base_type)   , pointer             :: cur_goveq
@@ -1236,7 +1236,7 @@ contains
     character(len =*)                           :: unit
     PetscInt                                    :: cond_type
     PetscInt, optional                          :: region_type
-    type(connection_set_type),pointer, optional :: conn_set
+    class(connection_set_type),pointer, optional :: conn_set
     !
     class(goveqn_base_type),pointer             :: cur_goveq
     class(goveqn_base_type),pointer             :: other_goveq

--- a/src/mpp/soe/SystemOfEquationsBaseType.F90
+++ b/src/mpp/soe/SystemOfEquationsBaseType.F90
@@ -488,7 +488,7 @@ contains
 
           if (soe%solver%use_dynamic_linesearch .and. linesearch_iter < max_linesearch_iter) then
              ! Let's try another linesearch
-             write(iulog,*),'On proc ', soe%mpi_rank, ' time_step = ', soe%nstep, &
+             write(iulog,*) 'On proc ', soe%mpi_rank, ' time_step = ', soe%nstep, &
                   linesearch_name // ' unsuccessful. Trying another one.'
              call VecCopy(soe%solver%soln_prev, soe%solver%soln, ierr); CHKERRQ(ierr)
           else
@@ -499,7 +499,7 @@ contains
              ! SNES diverged, so let's cut the timestep and try again.
              num_time_cuts = num_time_cuts + 1
              dt_iter = 0.5d0*dt_iter
-             write(iulog,*),'On proc ', soe%mpi_rank, ' time_step = ', soe%nstep, &
+             write(iulog,*) 'On proc ', soe%mpi_rank, ' time_step = ', soe%nstep, &
                   'snes_reason = ',snes_reason,' cutting dt to ',dt_iter
           endif
 

--- a/src/mpp/soe/SystemOfEquationsLBLType.F90
+++ b/src/mpp/soe/SystemOfEquationsLBLType.F90
@@ -238,9 +238,6 @@ contains
     allocate (dms(nDM))
     call DMCompositeGetEntriesArray(this%solver%dm, dms, ierr); CHKERRQ(ierr)
 
-    ! Initialize the matrix
-    call MatZeroEntries(B, ierr); CHKERRQ(ierr)
-
     ! Get submatrices
     allocate(is(nDM))
     allocate(B_submats(nDM,nDM))

--- a/src/mpp/soe/SystemOfEquationsLongwaveType.F90
+++ b/src/mpp/soe/SystemOfEquationsLongwaveType.F90
@@ -213,9 +213,6 @@ contains
     allocate (dms(nDM))
     call DMCompositeGetEntriesArray(this%solver%dm, dms, ierr); CHKERRQ(ierr)
 
-    ! Initialize the matrix
-    call MatZeroEntries(B, ierr); CHKERRQ(ierr)
-
     ! Get submatrices
     allocate(is(nDM))
     allocate(B_submats(nDM,nDM))

--- a/src/mpp/soe/SystemOfEquationsMLCType.F90
+++ b/src/mpp/soe/SystemOfEquationsMLCType.F90
@@ -339,6 +339,7 @@ contains
     class(sysofeqns_mlc_type) :: this
     KSP                       :: ksp
     Mat                       :: A, B
+    MatType                   :: mat_type
     PetscErrorCode            :: ierr
 
     !
@@ -360,8 +361,10 @@ contains
     allocate (dms(nDM))
     call DMCompositeGetEntriesArray(this%solver%dm, dms, ierr); CHKERRQ(ierr)
 
-    ! Initialize the matrix
-    call MatZeroEntries(B, ierr); CHKERRQ(ierr)
+    ! Note: Previously there was a MatZeroEntries() call here to initialize the entries of B to zero.
+    ! This is no longer needed now that we are using MatPreallocatorPreallocate() to do the preallocation for
+    ! the matrix, as we are instructing MatPreallocatorPreallocate() to zero the entires when it does the
+    ! preallocation.
 
     ! Get submatrices
     allocate(is(nDM))

--- a/src/mpp/soe/SystemOfEquationsThermalType.F90
+++ b/src/mpp/soe/SystemOfEquationsThermalType.F90
@@ -683,9 +683,6 @@ contains
     allocate (dms(nDM))
     call DMCompositeGetEntriesArray(this%solver%dm, dms, ierr); CHKERRQ(ierr)
 
-    ! Initialize the matrix
-    call MatZeroEntries(B, ierr); CHKERRQ(ierr)
-
     ! Get submatrices
     allocate(is(nDM))
     allocate(B_submats(nDM,nDM))

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 include_directories(${CMAKE_BINARY_DIR}/src/mpp/util)
 
 link_libraries(${MPP_LIBRARIES})
+link_directories(${PETSC_LIBRARY_DIRS})
 link_libraries(${PETSC_LIBRARIES})
 link_libraries(${NETCDF_LIBRARY})
 link_libraries(${NETCDF_F90_LIBRARIES})


### PR DESCRIPTION
This PR accomplishes two major things:

1. It uses `MATPREALLOCATOR` to do accurate matrix preallocation for the global operator, which greatly improves the overall runtime of the code without incurring high memory expense; previous approaches, if avoiding (very slow) `malloc()` calls in the matrix assembly, used far too much memory.
2. It makes several changes to better follow the modern Fortran standards, so that the code now compiles with Gfortran, Flang / AMD, and the Cray Fortran compilers. Previously, the code would only build reliably using GFortran.

This branch started from an older one identified as being suitable for GPU testing, and it does have several conflicts with `main` that need to be resolved before this PR can be merged. I don't think this involves anything difficult, but it will take a bit of time and being careful, so I'd like @bishtgautam to approve what I've done here before I rebase this over `main`.